### PR TITLE
Move module initialization logs from info level to debug level

### DIFF
--- a/aubase410/gen_initializer.bal
+++ b/aubase410/gen_initializer.bal
@@ -198,5 +198,5 @@ function init() returns r4:FHIRError? {
     r4:FHIRImplementationGuide baseImplementationGuide = new(baseIgRecord);
     check fhirRegistry.addImplementationGuide(baseImplementationGuide);
 
-    log:printInfo("FHIR R4 AUBase Module initialized.");
+    log:printDebug("FHIR R4 AUBase Module initialized.");
 }

--- a/base/gen_initializer.bal
+++ b/base/gen_initializer.bal
@@ -759,5 +759,5 @@ function init() returns FHIRError? {
     FHIRImplementationGuide baseImplementationGuide = new (baseIgRecord);
     check fhirRegistry.addImplementationGuide(baseImplementationGuide);
 
-    log:printInfo("FHIR R4 Module initialized.");
+    log:printDebug("FHIR R4 Module initialized.");
 }

--- a/uscore501/gen_initializer.bal
+++ b/uscore501/gen_initializer.bal
@@ -173,5 +173,5 @@ function init() returns r4:FHIRError? {
     r4:FHIRImplementationGuide baseImplementationGuide = new(baseIgRecord);
     check fhirRegistry.addImplementationGuide(baseImplementationGuide);
 
-    log:printInfo("FHIR R4 USCore Module initialized.");
+    log:printDebug("FHIR R4 USCore Module initialized.");
 }


### PR DESCRIPTION
Move module initialization logs from info level to debug level in following packages.

- r4
- uscore501
- aubase410

Related issue: https://github.com/wso2-enterprise/open-healthcare/issues/1223