### PR TITLE
Add location header when creating resources

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/core.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/core.bal
@@ -22,6 +22,7 @@ const PATIENT_ID_QUERY_PARAM = "_id";
 const PATIENT_QUERY_PARAM = "patient";
 const HISTORY = "_history";
 const METADATA = "metadata";
+const LOCATION_HEADER = "Location";
 
 // FHIR interaction records
 # FHIR Read interaction.

--- a/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
@@ -141,6 +141,13 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
                         fhirContext.setErrorCode(r4:getErrorCode(executeResourceResult));
                         return r4:handleErrorResponse(executeResourceResult);
                     }
+                    if executeResourceResult is r4:DomainResource {
+                        string? createdId = executeResourceResult.id;
+                        if createdId is string {
+                            string location = string `${fhirResource}/${createdId}`;
+                            fhirContext.setProperty(r4:LOCATION_HEADER_PROP_NAME, location);
+                        }
+                    }
                     return executeResourceResult;
                 } else {
                     return r4:createFHIRError(string `Path not found: ${req.extraPathInfo}`, r4:CODE_SEVERITY_ERROR, r4:TRANSIENT, httpStatusCode = http:STATUS_NOT_FOUND);

--- a/fhirr4/ballerina/src/main/resources/fhirservice/response_interceptors.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/response_interceptors.bal
@@ -68,6 +68,12 @@ public isolated service class FHIRResponseInterceptor {
             }
         }
 
+        // set the location header if available
+        anydata? location = fhirContext.getProperty(r4:LOCATION_HEADER_PROP_NAME);
+        if location is string {
+            res.setHeader(LOCATION_HEADER, location);
+        }
+
         if fhirContext.isInErrorState() {
             // set the proper response code
             res.statusCode = fhirContext.getErrorCode();


### PR DESCRIPTION
Fixing: https://github.com/wso2-enterprise/open-healthcare/issues/1300

* Added a map in the fhir ctx to hold properties.
* Extract the created resource id in the post path of the fhir service and set it as a property to fhir ctx.
* Get the location header property from the fhir ctx and set it to HTTP response in the response interceptor.