### PR TITLE
Add response content type and remove validating fhir+xml

### DIFF
--- a/base/fhir_preprocessor.bal
+++ b/base/fhir_preprocessor.bal
@@ -371,12 +371,9 @@ isolated function validateClientRequestHeaders(http:Request request) returns FHI
         "application/fhir+json" => {
             headers.contentType = JSON;
         }
-        "application/fhir+xml" => {
-            headers.contentType = XML;
-        }
         _ => {
-            string message = string `Incorrect Content-Type header value of \"${contentType}\" was provided in the request. 
-                A valid FHIR Content-Type (\"application/fhir+json\" or \"application/fhir+xml\") is required.`;
+            string message = string `Unsupported Content-Type header value of \"${contentType}\" was provided in the request. 
+                Only \"application/fhir+json\" is supported.`;
             return createFHIRError(message, ERROR, PROCESSING, message, errorType = VALIDATION_ERROR, httpStatusCode = http:STATUS_UNSUPPORTED_MEDIA_TYPE);
         }
     }
@@ -393,12 +390,9 @@ isolated function validateClientRequestHeaders(http:Request request) returns FHI
             "application/fhir+json" => {
                 headers.acceptType = JSON;
             }
-            "application/fhir+xml" => {
-                headers.acceptType = XML;
-            }
             _ => {
-                string message = string `Incorrect Accept header value of \"${acceptHeader}\" was provided in the request. 
-                    A valid FHIR Accept (\"application/fhir+json\" or \"application/fhir+xml\") type is required.`;
+                string message = string `Unsupported Accept header value of \"${acceptHeader}\" was provided in the request. 
+                    Only \"application/fhir+json\" is supported.`;
                 return createFHIRError(message, ERROR, PROCESSING, message, errorType = VALIDATION_ERROR, httpStatusCode = http:STATUS_NOT_ACCEPTABLE);
             }
         }

--- a/base/response_interceptors.bal
+++ b/base/response_interceptors.bal
@@ -44,6 +44,14 @@ public isolated service class FHIRResponseInterceptor {
 
         check self.postProcessSearchParameters(fhirContext);
 
+        // set the content type to fhir+json if the response is a json payload
+        if res.getJsonPayload() is json {
+            error? setType = res.setContentType(FHIR_MIME_TYPE_JSON);
+            if setType is error {
+                // ignore since the content type is set internally and not by a client
+            }
+        }
+
         if (fhirContext.isInErrorState()) {
             // set the proper response code
             res.statusCode = fhirContext.getErrorCode();
@@ -90,50 +98,58 @@ public isolated service class FHIRResponseErrorInterceptor {
             match err.detail().httpStatusCode {
                 http:STATUS_NOT_FOUND => {
                     http:NotFound notFound = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return notFound;
                 }
                 http:STATUS_BAD_REQUEST => {
                     http:BadRequest badRequest = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return badRequest;
                 }
                 http:STATUS_UNSUPPORTED_MEDIA_TYPE => {
                     http:UnsupportedMediaType unsupportedMediaType = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return unsupportedMediaType;
                 }
                 http:STATUS_NOT_ACCEPTABLE => {
                     http:NotAcceptable notAcceptable = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return notAcceptable;
                 }
                 http:STATUS_UNAUTHORIZED => {
                     http:Unauthorized unauthorized = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return unauthorized;
                 }
                 http:STATUS_NOT_IMPLEMENTED => {
                     http:NotImplemented notImplemented = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return notImplemented;
                 }
                 _ => {
                     http:InternalServerError internalServerError = {
-                        body: handleErrorResponse(err)
+                        body: handleErrorResponse(err),
+                        mediaType: FHIR_MIME_TYPE_JSON
                     };
                     return internalServerError;
                 }
             }
         }
         http:InternalServerError internalServerError = {
-            body: handleErrorResponse(err)
+            body: handleErrorResponse(err),
+            mediaType: FHIR_MIME_TYPE_JSON
         };
         return internalServerError;
     }


### PR DESCRIPTION
* add content type in the response interceptor.
*  avoid allowing fhir+xml in accept and content type headers since it's not supported yet by our packages.

fixing: https://github.com/wso2-enterprise/open-healthcare/issues/1311