### PR TITLE
Fixed issues in fhirr4 and ci workflows

### DIFF
--- a/.github/workflows/cd-fhirr4.yml
+++ b/.github/workflows/cd-fhirr4.yml
@@ -14,8 +14,8 @@ on:
 
 jobs:
   build:
-     uses: ./.github/workflows/build-executor.yml
+     uses: ./.github/workflows/fhirr4-build-executor.yml
      secrets: inherit
      with:
-      working_dir: ./fhirr4/ballerina/src/main/resources/fhirservice
+      working_dir: ./fhirr4
       bal_central_environment: ${{ inputs.bal_central_environment }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   R4_PATTERN: '*/*'
+  FHIRR4_PATTERN: 'fhirr4/*/*'
   UTILS_PATTERN: 'utils/*/*'
   GITHUB_WORKFLOWS_DIR: '.github'
 
@@ -41,6 +42,8 @@ jobs:
           for file in "${CHANGED_FILES_ARRAY[@]}"; do
             if [[ $file == $UTILS_PATTERN ]]; then
               EXTRACTED_PATH=$(echo "$file" | cut -d '/' -f 1-2)
+            elif [[ $file == $FHIRR4_PATTERN ]]; then
+              EXTRACTED_PATH=$(echo "$file" | cut -d '/' -f 1-6)
             elif [[ $file == $R4_PATTERN ]]; then
               EXTRACTED_PATH=$(echo "$file" | cut -d '/' -f 1)
             fi
@@ -77,12 +80,44 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Ballerina Build
+        if: ${{ matrix.path != 'fhirr4/ballerina/src/main/resources/fhirservice' }}
         uses: ballerina-platform/ballerina-action@2201.7.0
         with:
           args: pack
         env:
           WORKING_DIR: ./${{ matrix.path }}
           JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Setup Maven
+        if: ${{ matrix.path == 'fhirr4/ballerina/src/main/resources/fhirservice' }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - uses: ballerina-platform/setup-ballerina@v1.1.0
+        if: ${{ matrix.path == 'fhirr4/ballerina/src/main/resources/fhirservice' }}
+        name: Setup latest Ballerina version
+        with:
+          version: 2201.7.0
+
+      - name: Create settings.xml
+        if: ${{ matrix.path == 'fhirr4/ballerina/src/main/resources/fhirservice' }}
+        run: echo '<settings>
+              <servers>
+                <server>
+                  <id>ballerina-language-repo</id>
+                  <username>${{ github.actor }}</username>
+                  <password>${{ secrets.PAT_TOKEN }}</password>
+                </server>
+              </servers>
+            </settings>' > ~/.m2/settings.xml
+
+      - name: Run maven build
+        if: ${{ matrix.path == 'fhirr4/ballerina/src/main/resources/fhirservice' }}
+        run: |
+          cd fhirr4
+          mvn clean install
 
   test:
     needs: [ setup ]
@@ -99,6 +134,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Ballerina Test
+        if: ${{ matrix.path != 'fhirr4/ballerina/src/main/resources/fhirservice' }}
         uses: ballerina-platform/ballerina-action@2201.7.0
         with:
           args: test --code-coverage
@@ -107,6 +143,7 @@ jobs:
           JAVA_HOME: /usr/lib/jvm/default-jvm
 
       - name: Read Ballerina Test Results
+        if: ${{ matrix.path != 'fhirr4/ballerina/src/main/resources/fhirservice' }}
         id: test_results
         run: |
           if [ -f "./${{ matrix.path }}/target/report/test_results.json" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - uses: ballerina-platform/setup-ballerina@v1.1.0
+      - name: Setup latest Ballerina version
+        uses: ballerina-platform/setup-ballerina@v1.1.0
         if: ${{ matrix.path == 'fhirr4/ballerina/src/main/resources/fhirservice' }}
-        name: Setup latest Ballerina version
         with:
           version: 2201.7.0
 
@@ -116,8 +116,7 @@ jobs:
       - name: Run maven build
         if: ${{ matrix.path == 'fhirr4/ballerina/src/main/resources/fhirservice' }}
         run: |
-          cd fhirr4
-          mvn clean install
+         mvn clean install -f fhirr4
 
   test:
     needs: [ setup ]

--- a/.github/workflows/fhirr4-build-executor.yml
+++ b/.github/workflows/fhirr4-build-executor.yml
@@ -24,8 +24,8 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - uses: ballerina-platform/setup-ballerina@v1.1.0
-        name: Setup latest Ballerina version
+      - name: Setup latest Ballerina version
+        uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
           version: 2201.7.0
       
@@ -45,8 +45,7 @@ jobs:
 
       - name: Run maven build
         run: |
-          cd fhirr4
-          mvn clean install
+         mvn clean install -f fhirr4
 
       - name: Push to Staging
         if: inputs.bal_central_environment == 'STAGE'
@@ -55,32 +54,10 @@ jobs:
           args:
                push
         env:
-              WORKING_DIR:  ${{ inputs.working_dir }}
+              WORKING_DIR: /fhirr4/ballerina/target/classes/fhirservice
               JAVA_HOME: /usr/lib/jvm/default-jvm
               BALLERINA_STAGE_CENTRAL: true
               BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
-
-      - name: Run ballerina build for dev
-        if: inputs.bal_central_environment == 'DEV'
-        uses: ballerina-platform/ballerina-action@2201.7.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm 
-          BALLERINA_DEV_CENTRAL: true
-          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }} 
-
-      - name: Run ballerina build for prod
-        if: inputs.bal_central_environment == 'PROD'
-        uses: ballerina-platform/ballerina-action@2201.7.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm 
 
       - name: Push to Dev
         if: inputs.bal_central_environment == 'DEV'
@@ -89,7 +66,7 @@ jobs:
           args:
             push
         env:
-          WORKING_DIR: ${{ inputs.working_dir }}
+          WORKING_DIR: /fhirr4/ballerina/target/classes/fhirservice
           JAVA_HOME: /usr/lib/jvm/default-jvm
           BALLERINA_DEV_CENTRAL: true
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}     
@@ -101,7 +78,7 @@ jobs:
           args:
             push
         env:
-          WORKING_DIR: ${{ inputs.working_dir }}
+          WORKING_DIR: /fhirr4/ballerina/target/classes/fhirservice
           JAVA_HOME: /usr/lib/jvm/default-jvm
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
 
@@ -140,15 +117,10 @@ jobs:
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Ballerina Build after incrementing version
+      - name: Maven Build after incrementing version
         if: ${{ inputs.bal_central_environment == 'PROD' }}
-        uses: ballerina-platform/ballerina-action@2201.7.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm
+        run: |
+         mvn clean install -f fhirr4
 
       - name: Commit changes and make a PR
         if: ${{ inputs.bal_central_environment == 'PROD' }}

--- a/.github/workflows/fhirr4-build-executor.yml
+++ b/.github/workflows/fhirr4-build-executor.yml
@@ -1,0 +1,184 @@
+name: fhirr4-build
+
+on:
+  workflow_call:
+    inputs:
+      working_dir:
+        required: true
+        type: string
+      bal_central_environment:
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+       JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - uses: ballerina-platform/setup-ballerina@v1.1.0
+        name: Setup latest Ballerina version
+        with:
+          version: 2201.7.0
+      
+      - name: Print ballerina version
+        run: bal version
+
+      - name: Create settings.xml
+        run: echo '<settings>
+              <servers>
+                <server>
+                  <id>ballerina-language-repo</id>
+                  <username>${{ github.actor }}</username>
+                  <password>${{ secrets.PAT_TOKEN }}</password>
+                </server>
+              </servers>
+            </settings>' > ~/.m2/settings.xml
+
+      - name: Run maven build
+        run: |
+          cd fhirr4
+          mvn clean install
+
+      - name: Push to Staging
+        if: inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.7.0
+        with:
+          args:
+               push
+        env:
+              WORKING_DIR:  ${{ inputs.working_dir }}
+              JAVA_HOME: /usr/lib/jvm/default-jvm
+              BALLERINA_STAGE_CENTRAL: true
+              BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Run ballerina build for dev
+        if: inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.7.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm 
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }} 
+
+      - name: Run ballerina build for prod
+        if: inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.7.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm 
+
+      - name: Push to Dev
+        if: inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.7.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}     
+
+      - name: Push to Prod
+        if: inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.7.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ${{ inputs.working_dir }}/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ${{ inputs.working_dir }}/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.7.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Extract the package name from working directory 
+          packageName=$(basename ${{ inputs.working_dir }})
+
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ${{ inputs.working_dir }}/Ballerina.toml
+          git add ${{ inputs.working_dir }}/Dependencies.toml    
+          git commit -m "[Release ${packageName} ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release '"$packageName"' ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/fhirr4-build-executor.yml
+++ b/.github/workflows/fhirr4-build-executor.yml
@@ -105,22 +105,21 @@ jobs:
             }' \
             "https://api.github.com/repos/${{ github.repository }}/releases"
 
-      - name: Update version in Ballerina.toml
+      - name: Update version in the pom files
         if: ${{ inputs.bal_central_environment == 'PROD' }}
         id: increment_patch_version
         run: |
-          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ${{ inputs.working_dir }}/Ballerina.toml)
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=<version>)[\d.]+' ${{ inputs.working_dir }}/pom.xml)
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
           PATCH_VERSION=$((VERSION_PARTS[2] + 1))
           NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION"
-          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ${{ inputs.working_dir }}/Ballerina.toml
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Maven Build after incrementing version
-        if: ${{ inputs.bal_central_environment == 'PROD' }}
-        run: |
-         mvn clean install -f fhirr4
+          #Bump the versions in each pom file in fhirr4
+          sed -i "0,/<version>${CURRENT_VERSION}<\/version>/s//<version>${NEW_VERSION}<\/version>/" ${{ inputs.working_dir }}/pom.xml
+          sed -i "0,/<version>${CURRENT_VERSION}<\/version>/s//<version>${NEW_VERSION}<\/version>/" ${{ inputs.working_dir }}/compiler-plugin/pom.xml
+          sed -i "0,/<version>${CURRENT_VERSION}<\/version>/s//<version>${NEW_VERSION}<\/version>/" ${{ inputs.working_dir }}/native/pom.xml
+          sed -i "0,/<version>${CURRENT_VERSION}<\/version>/s//<version>${NEW_VERSION}<\/version>/" ${{ inputs.working_dir }}/ballerina/pom.xml
 
       - name: Commit changes and make a PR
         if: ${{ inputs.bal_central_environment == 'PROD' }}
@@ -131,7 +130,10 @@ jobs:
           # Commit changes
           git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
-          git add ${{ inputs.working_dir }}/Ballerina.toml
+          git add ${{ inputs.working_dir }}/pom.xml
+          git add ${{ inputs.working_dir }}/ballerina/pom.xml
+          git add ${{ inputs.working_dir }}/compiler-plugin/pom.xml
+          git add ${{ inputs.working_dir }}/native/pom.xml
           git add ${{ inputs.working_dir }}/Dependencies.toml    
           git commit -m "[Release ${packageName} ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
           git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}

--- a/.github/workflows/fhirr4-build-executor.yml
+++ b/.github/workflows/fhirr4-build-executor.yml
@@ -133,8 +133,7 @@ jobs:
           git add ${{ inputs.working_dir }}/pom.xml
           git add ${{ inputs.working_dir }}/ballerina/pom.xml
           git add ${{ inputs.working_dir }}/compiler-plugin/pom.xml
-          git add ${{ inputs.working_dir }}/native/pom.xml
-          git add ${{ inputs.working_dir }}/Dependencies.toml    
+          git add ${{ inputs.working_dir }}/native/pom.xml   
           git commit -m "[Release ${packageName} ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
           git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
           


### PR DESCRIPTION
1) Added separate workflow for the fhirr4 as it uses maven build.
2) Changed the ci workflow so that it works with the maven build (it uses maven build for fhirr4 only and uses bal build for other packages). 
3) Added code so that the versions in the pom files of fhirr4 are updated instead of the version in ballerina.toml.