### PR TITLE
Remove distinct keyword from FHIRError subtypes

### DIFF
--- a/r4/Dependencies.toml
+++ b/r4/Dependencies.toml
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -44,7 +44,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.5.0"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}

--- a/r4/errors.bal
+++ b/r4/errors.bal
@@ -25,19 +25,19 @@ public type FHIRErrorType distinct (error<FHIRErrorDetail>);
 public type FHIRError distinct FHIRErrorType;
 
 # FHIR validation related error
-public type FHIRValidationError distinct FHIRError;
+public type FHIRValidationError FHIRError;
 
 # FHIR validation related error
-public type FHIRParseError distinct FHIRError;
+public type FHIRParseError FHIRError;
 
 # FHIR processing related issue related error
-public type FHIRProcessingError distinct FHIRError;
+public type FHIRProcessingError FHIRError;
 
 # FHIR serializer error
-public type FHIRSerializerError distinct FHIRError;
+public type FHIRSerializerError FHIRError;
 
 # FHIR data/resource type related error
-public type FHIRTypeError distinct FHIRError;
+public type FHIRTypeError FHIRError;
 
 # Code that describes the type of issue.
 public enum IssueType {


### PR DESCRIPTION
Remove distinct keyword from FHIRError subtypes as it conflicts with the definition and usage of FHIRError subtypes.