### PR TITLE
Add error message parsing for validator

### DIFF
--- a/validator/validator.bal
+++ b/validator/validator.bal
@@ -147,7 +147,7 @@ isolated function parseConstraintErrors(string message) returns string[] {
             if result is regexp:Groups {
                 regexp:Span? value = result[1];
                 if value !is () {
-                    errors.push("Invalid pattern (constraint) for field '" + value.substring() + "'");
+                    errors.push(string `Invalid pattern (constraint) for field '${value.substring()}'`);
                 }
             }
         }
@@ -163,18 +163,18 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
     //Removes related content if fhir multitype scenario is present so that it can be styled differently
     //The regex searches for a '{' enclosed within \n tags which signifies the start of multitype error.
-    string:RegExp regex1 = re `\n\s*\{[\s\S]*`;
-    string editedMessage = regex1.replace(message, "");
+    string:RegExp removeMultitypeRegex = re `\n\s*\{[\s\S]*`;
+    string editedMessage = removeMultitypeRegex.replace(message, "");
 
-    string:RegExp regex2 = re `\n`;
-    string[] data = regex2.split(editedMessage);
+    string:RegExp splitErrorRegex = re `\n`;
+    string[] data = splitErrorRegex.split(editedMessage);
 
     foreach var i in 0 ... data.length() - 1 {
 
         //Parsing for resource Type
         regexp:Groups? resourceType = re `Failed to find FHIR profile for the resource type`.findGroups(data[i]);
         if resourceType is regexp:Groups {
-            errors.push("Resource type is invalid");
+            errors.push(string `Resource type is invalid`);
         }
 
         //Parsing for missing fields
@@ -182,8 +182,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
         if missingFieldsData is regexp:Groups {
             regexp:Span? value = missingFieldsData[1];
             if value !is () {
-                errors.push("Missing required field '" + value.substring() + "'");
-
+                errors.push(string `Missing required field '${value.substring()}'`);
             }
         }
 
@@ -192,7 +191,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
         if missingElementsData is regexp:Groups {
             regexp:Span? value = missingElementsData[1];
             if value !is () {
-                errors.push("Missing required Element: '" + value.substring() + "'");
+                errors.push(string `Missing required Element: '${value.substring()}'`);
             }
         }
 
@@ -203,17 +202,17 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             string fieldData = "";
             regexp:Span? value = invalidFieldData[1];
             if value !is () {
-                fieldName = "Invalid field '" + value.substring() + "'";
+                fieldName = string `Invalid field '${value.substring()}'`;
             }
             //To get the expected type from the error message
             regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
             if expectedDataFormat is regexp:Groups {
                 regexp:Span? dataType = expectedDataFormat[1];
                 if dataType !is () {
-                    fieldData = "Type of field should be '" + dataType.substring() + "'";
+                    fieldData = string `Type of field should be '${dataType.substring()}'`;
                 }
             }
-            errors.push(fieldName + ". " + fieldData);
+            errors.push(string `${fieldName}. ${fieldData}`);
         }
 
         //Parsing for invalid field values
@@ -223,17 +222,17 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             string valueData = "";
             regexp:Span? value = invalidValuesData[1];
             if value !is () {
-                valueName = "Invalid value of field '" + value.substring() + "'";
+                valueName = string `Invalid value of field '${value.substring()}'`;
             }
             //To get the expected type from the error message
             regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
             if expectedDataFormat is regexp:Groups {
                 regexp:Span? dataType = expectedDataFormat[1];
                 if dataType !is () {
-                    valueData = "Type of value should be '" + dataType.substring() + "'";
+                    valueData = string `Type of value should be '${dataType.substring()}'`;
                 }
             }
-            errors.push(valueName + ". " + valueData);
+            errors.push(string `${valueName}. ${valueData}`);
         }
 
         //Parsing for invalid array elements
@@ -243,17 +242,17 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             string valueData = "";
             regexp:Span? value = invalidArrayElementsData[1];
             if value !is () {
-                valueName = "Invalid array element '" + value.substring() + "'";
+                valueName = string `Invalid array element '${value.substring()}'`;
             }
             //To get the expected type from the error message
             regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
             if expectedDataFormat is regexp:Groups {
                 regexp:Span? dataType = expectedDataFormat[1];
                 if dataType !is () {
-                    valueData = "Type of element should be '" + dataType.substring() + "'";
+                    valueData = string `Type of element should be '${dataType.substring()}'`;
                 }
             }
-            errors.push(valueName + ". " + valueData);
+            errors.push(string `${valueName}. ${valueData}`);
         }
 
         //Add parsing logic here for other parser errors
@@ -268,7 +267,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
         if value !is () {
             string capturedString = value.substring();
             //Splits message into lines based on \n
-            string[] capturedErrors = regex2.split(capturedString);
+            string[] capturedErrors = splitErrorRegex.split(capturedString);
 
             string valueName = "";
             //To get the field name from the error message if error is with the value
@@ -278,7 +277,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
                     regexp:Span? fieldData = capturedData[1];
                     if fieldData !is () {
                         valueName = fieldData.substring();
-                        errors.push("The field '" + valueName + "' should be of type value[x] or url[x] where x is a valid fhir data type");
+                        errors.push(string `The field '${valueName}' should be of type value[x] or url[x] where x is a valid fhir data type`);
                         break;
                     }
                 }
@@ -291,7 +290,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
                         regexp:Span? fieldData = capturedData[1];
                         if fieldData !is () {
                             valueName = fieldData.substring();
-                            errors.push("The field '" + valueName + "' should be of type value[x] or url[x] where x is a valid fhir data type");
+                            errors.push(string `The field '${valueName}' should be of type value[x] or url[x] where x is a valid fhir data type`);
                             break;
                         }
                     }

--- a/validator/validator.bal
+++ b/validator/validator.bal
@@ -139,8 +139,9 @@ isolated function parseConstraintErrors(string message) returns string[] {
     string:RegExp regex = re `\n`;
     string[] data = regex.split(message);
 
-    //Parsing for dateTime errors.
     foreach var i in 0 ... data.length() - 1 {
+
+        //Parsing for dateTime errors.
         regexp:Groups[] invalidDates = re `\$\.([\w\.\[\]]+):pattern`.findAllGroups(data[i]);
         foreach regexp:Groups result in invalidDates {
             if result is regexp:Groups {
@@ -150,6 +151,8 @@ isolated function parseConstraintErrors(string message) returns string[] {
                 }
             }
         }
+
+        //Add parsing logic here for other constraint errors
     }
     return errors;
 }
@@ -252,6 +255,8 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             }
             errors.push(valueName + ". " + valueData);
         }
+
+        //Add parsing logic here for other parser errors
 
     }
 

--- a/validator/validator.bal
+++ b/validator/validator.bal
@@ -97,7 +97,7 @@ public isolated function validate(json|anydata data, typedesc<anydata>? targetFH
         anydata|r4:FHIRParseError parsedResult = parser:parse(data, targetFHIRModelType);
 
         if parsedResult is r4:FHIRParseError {
-            log:printDebug("Error is a FHIRParseError");
+            log:printDebug(string `FHIR parsing failed, ${parsedResult.message()}`);
             string[] errors = processFHIRParserErrors(parsedResult.message());
             return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed", r4:ERROR, r4:INVALID, parsedResult.message(),
                                                 errorType = r4:VALIDATION_ERROR, cause = parsedResult, parsedErrors = errors);
@@ -114,7 +114,7 @@ public isolated function validate(json|anydata data, typedesc<anydata>? targetFH
     anydata|constraint:Error validationResult = constraint:validate(finalData, typeDescOfData);
 
     if validationResult is constraint:Error {
-        log:printDebug("Error is a constraint:Error");
+        log:printDebug(string `Constraint validation failed, ${validationResult.message()}`);
         string[] errors = parseConstraintErrors(validationResult.message());
         return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed", r4:ERROR, r4:INVALID, validationResult.message(),
                                                 errorType = r4:VALIDATION_ERROR, cause = validationResult, parsedErrors = errors);
@@ -144,7 +144,7 @@ isolated function parseConstraintErrors(string message) returns string[] {
         //Parsing for dateTime errors.
         regexp:Groups[] invalidDates = re `\$\.([\w\.\[\]]+):pattern`.findAllGroups(data[i]);
         foreach regexp:Groups result in invalidDates {
-            if result is regexp:Groups {
+            if (result is regexp:Groups && result.length() > 1) {
                 regexp:Span? value = result[1];
                 if value !is () {
                     errors.push(string `Invalid pattern (constraint) for field '${value.substring()}'`);
@@ -179,7 +179,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
         //Parsing for missing fields
         regexp:Groups? missingFieldsData = re `missing required field '([^']+)'`.findGroups(data[i]);
-        if missingFieldsData is regexp:Groups {
+        if (missingFieldsData is regexp:Groups && missingFieldsData.length() > 1 ){
             regexp:Span? value = missingFieldsData[1];
             if value !is () {
                 errors.push(string `Missing required field '${value.substring()}'`);
@@ -188,7 +188,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
         //Parsing for missing elements(if resourcetype is msiisng)
         regexp:Groups? missingElementsData = re `missing required element: "([^""]+)"`.findGroups(data[i]);
-        if missingElementsData is regexp:Groups {
+        if (missingElementsData is regexp:Groups && missingElementsData.length() > 1 ){
             regexp:Span? value = missingElementsData[1];
             if value !is () {
                 errors.push(string `Missing required Element: '${value.substring()}'`);
@@ -197,7 +197,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
         //Parsing for Invalid fields
         regexp:Groups? invalidFieldData = re `value of field '([^']+)'`.findGroups(data[i]);
-        if invalidFieldData is regexp:Groups {
+        if (invalidFieldData is regexp:Groups && invalidFieldData.length() > 1 ){
             string fieldName = "";
             string fieldData = "";
             regexp:Span? value = invalidFieldData[1];
@@ -206,7 +206,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             }
             //To get the expected type from the error message
             regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
-            if expectedDataFormat is regexp:Groups {
+            if (expectedDataFormat is regexp:Groups && expectedDataFormat.length() > 1 ){
                 regexp:Span? dataType = expectedDataFormat[1];
                 if dataType !is () {
                     fieldData = string `Type of field should be '${dataType.substring()}'`;
@@ -217,7 +217,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
         //Parsing for invalid field values
         regexp:Groups? invalidValuesData = re `^\s*field '([^']+)'`.findGroups(data[i]);
-        if invalidValuesData is regexp:Groups {
+        if (invalidValuesData is regexp:Groups && invalidValuesData.length() > 1 ){
             string valueName = "";
             string valueData = "";
             regexp:Span? value = invalidValuesData[1];
@@ -226,7 +226,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             }
             //To get the expected type from the error message
             regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
-            if expectedDataFormat is regexp:Groups {
+            if (expectedDataFormat is regexp:Groups && expectedDataFormat.length() > 1 ){
                 regexp:Span? dataType = expectedDataFormat[1];
                 if dataType !is () {
                     valueData = string `Type of value should be '${dataType.substring()}'`;
@@ -237,7 +237,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
         //Parsing for invalid array elements
         regexp:Groups? invalidArrayElementsData = re `^\s*array element '([^']+)'`.findGroups(data[i]);
-        if invalidArrayElementsData is regexp:Groups {
+        if (invalidArrayElementsData is regexp:Groups && invalidArrayElementsData.length() > 1 ) {
             string valueName = "";
             string valueData = "";
             regexp:Span? value = invalidArrayElementsData[1];
@@ -246,7 +246,7 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             }
             //To get the expected type from the error message
             regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
-            if expectedDataFormat is regexp:Groups {
+            if (expectedDataFormat is regexp:Groups && expectedDataFormat.length() > 1 ){
                 regexp:Span? dataType = expectedDataFormat[1];
                 if dataType !is () {
                     valueData = string `Type of element should be '${dataType.substring()}'`;
@@ -259,7 +259,16 @@ isolated function processFHIRParserErrors(string message) returns string[] {
 
     }
 
-    //Parsing for fhir multitype scenario
+    //Parsing for fhir multitype scenario (when there is a union type) 
+    // Example of multitype error;
+    // {
+    //     missing required field 'x' of type 'health.fhir.r4:CodeableConcept' in record 'x'
+    //     value of field 'x' adding to the record 'x' should be of type 'x', found 'x'
+    // or
+    //     missing required field 'x' of type 'string' in record 'x'
+    //     value of field 'x' adding to the record 'x' should be of type 'x', found 'x'
+    // or
+
     //The regex captures a '{' enclosed within \n tags which signifies the start of multitype error.
     regexp:Groups? multitypeMessage = re `\n\s*\{[\s\S]*`.findGroups(message);
     if multitypeMessage is regexp:Groups {
@@ -270,10 +279,10 @@ isolated function processFHIRParserErrors(string message) returns string[] {
             string[] capturedErrors = splitErrorRegex.split(capturedString);
 
             string valueName = "";
-            //To get the field name from the error message if error is with the value
+            //To get the field name from the error message if error is with the VALUE
             foreach var i in 0 ... capturedErrors.length() - 1 {
                 regexp:Groups? capturedData = re `^\s*field '([^']+)'`.findGroups(capturedErrors[i]);
-                if capturedData is regexp:Groups {
+                if (capturedData is regexp:Groups && capturedData.length() > 1 ){
                     regexp:Span? fieldData = capturedData[1];
                     if fieldData !is () {
                         valueName = fieldData.substring();
@@ -283,10 +292,10 @@ isolated function processFHIRParserErrors(string message) returns string[] {
                 }
             }
             if (valueName === "") {
-                //To get the field name from the error message if error is with the field itself
+                //To get the field name from the error message if error is with the FIELD itself
                 foreach var i in 0 ... capturedErrors.length() - 1 {
                     regexp:Groups? capturedData = re `^\s* value of field '([^']+)'`.findGroups(capturedErrors[i]);
-                    if capturedData is regexp:Groups {
+                    if (capturedData is regexp:Groups && capturedData.length() > 1 ){
                         regexp:Span? fieldData = capturedData[1];
                         if fieldData !is () {
                             valueName = fieldData.substring();

--- a/validator/validator.bal
+++ b/validator/validator.bal
@@ -17,6 +17,71 @@
 import ballerina/constraint;
 import ballerinax/health.fhir.r4;
 import ballerinax/health.fhir.r4.parser;
+import ballerina/http;
+import ballerina/lang.regexp;
+import ballerina/log;
+
+# Record used to store user friendly error messages.
+#
+# + detailedErrors - User friendly error messages
+public type FHIRValidationIssueDetail record {
+    *r4:FHIRIssueDetail;
+    string[]? detailedErrors = ();
+};
+
+# Utility function to create FHIRError for validator.
+#
+# + message - Message to be added to the error
+# + errServerity - serverity of the error
+# + code - error code
+# + diagnostic - (optional) diagnostic message
+# + expression - (optional) FHIR Path expression to the error location
+# + cause - (optional) original error
+# + errorType - (optional) type of the error
+# + httpStatusCode - (optional) [default: 500] HTTP status code to return to the client
+# + return - Return Value Description
+# + parsedErrors - (optional) usefriendly error messages parsed from original error message
+public isolated function createValidationError(string message, r4:Severity errServerity, r4:IssueType code,
+        string? diagnostic = (), string[]? expression = (), error? cause = (),
+        r4:FHIRErrorTypes? errorType = (), string[]? parsedErrors = (), int httpStatusCode = http:STATUS_INTERNAL_SERVER_ERROR)
+        returns r4:FHIRError {
+    string diagnosticMessage = diagnostic != () ? string `${message} due to ${diagnostic}` : message;
+    string[] detailedErrors = parsedErrors != () ? parsedErrors : [diagnosticMessage];
+    boolean internal = false;
+    FHIRValidationIssueDetail issue = {
+        severity: errServerity,
+        code: code,
+        diagnostic: diagnostic,
+        expression: expression,
+        details: {
+            coding: [
+                {
+                    system: "http://hl7.org/fhir/issue-type",
+                    code: httpStatusCode.toString()
+                }
+            ],
+            text: message
+        },
+        detailedErrors: detailedErrors
+    };
+    match errorType {
+        r4:VALIDATION_ERROR => {
+            r4:FHIRValidationError fError = error(message, cause, issues = [issue], httpStatusCode = httpStatusCode,
+                                                        internalError = internal);
+            return fError;
+        }
+        r4:PARSE_ERROR => {
+            r4:FHIRParseError fError = error(message, cause, issues = [issue], httpStatusCode = httpStatusCode,
+                                                        internalError = internal);
+            return fError;
+        }
+        _ => {
+            r4:FHIRError fError = error(message, cause, issues = [issue], httpStatusCode = httpStatusCode,
+                                                        internalError = internal);
+            return fError;
+        }
+    }
+}
 
 # This method will validate FHIR resource.
 # Validation consist of Structure, cardinality, Value domain, Profile, json.
@@ -32,8 +97,10 @@ public isolated function validate(json|anydata data, typedesc<anydata>? targetFH
         anydata|r4:FHIRParseError parsedResult = parser:parse(data, targetFHIRModelType);
 
         if parsedResult is r4:FHIRParseError {
-            return <r4:FHIRValidationError>r4:createFHIRError("FHIR resource validation failed", r4:ERROR, r4:INVALID, parsedResult.message(),
-                                                errorType = r4:VALIDATION_ERROR, cause = parsedResult);
+            log:printDebug("Error is a FHIRParseError");
+            string[] errors = processFHIRParserErrors(parsedResult.message());
+            return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed", r4:ERROR, r4:INVALID, parsedResult.message(),
+                                                errorType = r4:VALIDATION_ERROR, cause = parsedResult, parsedErrors = errors);
         } else {
             finalData = parsedResult;
         }
@@ -47,8 +114,10 @@ public isolated function validate(json|anydata data, typedesc<anydata>? targetFH
     anydata|constraint:Error validationResult = constraint:validate(finalData, typeDescOfData);
 
     if validationResult is constraint:Error {
-        return <r4:FHIRValidationError>r4:createFHIRError("FHIR resource validation failed",r4:ERROR, r4:INVALID, validationResult.message(),
-                                                errorType = r4:VALIDATION_ERROR, cause = validationResult);
+        log:printDebug("Error is a constraint:Error");
+        string[] errors = parseConstraintErrors(validationResult.message());
+        return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed", r4:ERROR, r4:INVALID, validationResult.message(),
+                                                errorType = r4:VALIDATION_ERROR, cause = validationResult, parsedErrors = errors);
     }
 
 }
@@ -61,4 +130,169 @@ public isolated function validate(json|anydata data, typedesc<anydata>? targetFH
 # + return - If the validation fails, return validation error
 isolated function validateFhirResource(anydata data) returns r4:FHIRValidationError? {
     return validate(data);
+}
+
+isolated function parseConstraintErrors(string message) returns string[] {
+
+    string[] errors = [];
+
+    string:RegExp regex = re `\n`;
+    string[] data = regex.split(message);
+
+    //Parsing for dateTime errors.
+    foreach var i in 0 ... data.length() - 1 {
+        regexp:Groups[] invalidDates = re `\$\.([\w\.\[\]]+):pattern`.findAllGroups(data[i]);
+        foreach regexp:Groups result in invalidDates {
+            if result is regexp:Groups {
+                regexp:Span? value = result[1];
+                if value !is () {
+                    errors.push("Invalid pattern (constraint) for field '" + value.substring() + "'");
+                }
+            }
+        }
+    }
+    return errors;
+}
+
+isolated function processFHIRParserErrors(string message) returns string[] {
+
+    string[] errors = [];
+
+    //Removes related content if fhir multitype scenario is present so that it can be styled differently
+    //The regex searches for a '{' enclosed within \n tags which signifies the start of multitype error.
+    string:RegExp regex1 = re `\n\s*\{[\s\S]*`;
+    string editedMessage = regex1.replace(message, "");
+
+    string:RegExp regex2 = re `\n`;
+    string[] data = regex2.split(editedMessage);
+
+    foreach var i in 0 ... data.length() - 1 {
+
+        //Parsing for resource Type
+        regexp:Groups? resourceType = re `Failed to find FHIR profile for the resource type`.findGroups(data[i]);
+        if resourceType is regexp:Groups {
+            errors.push("Resource type is invalid");
+        }
+
+        //Parsing for missing fields
+        regexp:Groups? missingFieldsData = re `missing required field '([^']+)'`.findGroups(data[i]);
+        if missingFieldsData is regexp:Groups {
+            regexp:Span? value = missingFieldsData[1];
+            if value !is () {
+                errors.push("Missing required field '" + value.substring() + "'");
+
+            }
+        }
+
+        //Parsing for missing elements(if resourcetype is msiisng)
+        regexp:Groups? missingElementsData = re `missing required element: "([^""]+)"`.findGroups(data[i]);
+        if missingElementsData is regexp:Groups {
+            regexp:Span? value = missingElementsData[1];
+            if value !is () {
+                errors.push("Missing required Element: '" + value.substring() + "'");
+            }
+        }
+
+        //Parsing for Invalid fields
+        regexp:Groups? invalidFieldData = re `value of field '([^']+)'`.findGroups(data[i]);
+        if invalidFieldData is regexp:Groups {
+            string fieldName = "";
+            string fieldData = "";
+            regexp:Span? value = invalidFieldData[1];
+            if value !is () {
+                fieldName = "Invalid field '" + value.substring() + "'";
+            }
+            //To get the expected type from the error message
+            regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
+            if expectedDataFormat is regexp:Groups {
+                regexp:Span? dataType = expectedDataFormat[1];
+                if dataType !is () {
+                    fieldData = "Type of field should be '" + dataType.substring() + "'";
+                }
+            }
+            errors.push(fieldName + ". " + fieldData);
+        }
+
+        //Parsing for invalid field values
+        regexp:Groups? invalidValuesData = re `^\s*field '([^']+)'`.findGroups(data[i]);
+        if invalidValuesData is regexp:Groups {
+            string valueName = "";
+            string valueData = "";
+            regexp:Span? value = invalidValuesData[1];
+            if value !is () {
+                valueName = "Invalid value of field '" + value.substring() + "'";
+            }
+            //To get the expected type from the error message
+            regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
+            if expectedDataFormat is regexp:Groups {
+                regexp:Span? dataType = expectedDataFormat[1];
+                if dataType !is () {
+                    valueData = "Type of value should be '" + dataType.substring() + "'";
+                }
+            }
+            errors.push(valueName + ". " + valueData);
+        }
+
+        //Parsing for invalid array elements
+        regexp:Groups? invalidArrayElementsData = re `^\s*array element '([^']+)'`.findGroups(data[i]);
+        if invalidArrayElementsData is regexp:Groups {
+            string valueName = "";
+            string valueData = "";
+            regexp:Span? value = invalidArrayElementsData[1];
+            if value !is () {
+                valueName = "Invalid array element '" + value.substring() + "'";
+            }
+            //To get the expected type from the error message
+            regexp:Groups? expectedDataFormat = re `should be of type '([^']+)'`.findGroups(data[i]);
+            if expectedDataFormat is regexp:Groups {
+                regexp:Span? dataType = expectedDataFormat[1];
+                if dataType !is () {
+                    valueData = "Type of element should be '" + dataType.substring() + "'";
+                }
+            }
+            errors.push(valueName + ". " + valueData);
+        }
+
+    }
+
+    //Parsing for fhir multitype scenario
+    //The regex captures a '{' enclosed within \n tags which signifies the start of multitype error.
+    regexp:Groups? multitypeMessage = re `\n\s*\{[\s\S]*`.findGroups(message);
+    if multitypeMessage is regexp:Groups {
+        regexp:Span? value = multitypeMessage[0];
+        if value !is () {
+            string capturedString = value.substring();
+            //Splits message into lines based on \n
+            string[] capturedErrors = regex2.split(capturedString);
+
+            string valueName = "";
+            //To get the field name from the error message if error is with the value
+            foreach var i in 0 ... capturedErrors.length() - 1 {
+                regexp:Groups? capturedData = re `^\s*field '([^']+)'`.findGroups(capturedErrors[i]);
+                if capturedData is regexp:Groups {
+                    regexp:Span? fieldData = capturedData[1];
+                    if fieldData !is () {
+                        valueName = fieldData.substring();
+                        errors.push("The field '" + valueName + "' should be of type value[x] or url[x] where x is a valid fhir data type");
+                        break;
+                    }
+                }
+            }
+            if (valueName === "") {
+                //To get the field name from the error message if error is with the field itself
+                foreach var i in 0 ... capturedErrors.length() - 1 {
+                    regexp:Groups? capturedData = re `^\s* value of field '([^']+)'`.findGroups(capturedErrors[i]);
+                    if capturedData is regexp:Groups {
+                        regexp:Span? fieldData = capturedData[1];
+                        if fieldData !is () {
+                            valueName = fieldData.substring();
+                            errors.push("The field '" + valueName + "' should be of type value[x] or url[x] where x is a valid fhir data type");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return errors;
 }


### PR DESCRIPTION
## Purpose
> Add parsing for error messages returned by the backend, and re implemented createFHIRError of r4 inside the validator itself.

## Goals
> For the backend to return user friendly error messages together with the original ones.

## Approach
> The createFHIRError method was reimplemented as createValidationError inside the validator itself so that it's changes won't affect the r4. Created a new record FHIRValidationIssueDetail record which inherits  r4:FHIRIssueDetail.  Added a new field 'detailedErrors' inside FHIRValidationIssueDetail to hold the parsed error messages (the user friendly error messages).
Parsed the error messages returned by the backend and created a new set of error messages to be more user friendly which are stored in the instance of FHIRValidationIssueDetail .