### PR TITLE
Add FHIR extended operations support to FHIR service

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
@@ -15,6 +15,7 @@ import ballerina/jwt;
 import ballerina/lang.regexp;
 import ballerina/log;
 import ballerinax/health.fhir.r4;
+import ballerinax/health.fhir.r4.international401;
 import ballerinax/health.fhir.r4.parser;
 
 const SPACE_CHARACTER = " ";
@@ -32,6 +33,8 @@ public isolated class FHIRPreprocessor {
     final int pageSize;
     // All the active search parameters
     private final readonly & map<r4:SearchParamConfig> searchParamConfigMap;
+    // All the operations (base + API config defined)
+    private final readonly & map<r4:OperationConfig> operationConfigMap;
 
     # Initialize the FHIR pre-processor
     #
@@ -56,6 +59,29 @@ public isolated class FHIRPreprocessor {
             searchParamConfigs[item.name] = item;
         }
         self.searchParamConfigMap = searchParamConfigs.cloneReadOnly();
+
+        // Operations
+        map<r4:OperationConfig> operationConfigs = {};
+        // Add base resource operation configs
+        foreach r4:FHIROperationDefinition operationDefinition in r4:BASE_RESOURCE_OPERATIONS {
+            // Operation params
+            r4:FHIROperationParameterDefinition[]? 'parameter = operationDefinition.'parameter;
+            r4:OperationParamConfig[]? operationParams = 'parameter != () ? 'parameter.map(
+                isolated function(r4:FHIROperationParameterDefinition param) returns r4:OperationParamConfig {
+                    return {name: param.name, active: true};
+                }) : ();
+            r4:OperationConfig operationConfig = {
+                name: operationDefinition.name,
+                active: true,
+                parameters: operationParams.cloneReadOnly()
+            };
+            operationConfigs[operationDefinition.name] = operationConfig;
+        }
+        // Add resource specific operation configs
+        foreach r4:OperationConfig operationConfig in self.apiConfig.operations {
+            operationConfigs[operationConfig.name] = operationConfig;
+        }
+        self.operationConfigMap = operationConfigs.cloneReadOnly();
     }
 
     # Process the FHIR Read interaction.
@@ -213,7 +239,7 @@ public isolated class FHIRPreprocessor {
         // Create FHIR context
         r4:FHIRContext fCtx = new (fhirRequest, request, fhirSecurity);
 
-       // Create pagination context and set to FHIR context
+        // Create pagination context and set to FHIR context
         fCtx.setPaginationContext(check self.processPaginationParams(httpRequest));
 
         // Set FHIR context inside HTTP context
@@ -456,6 +482,92 @@ public isolated class FHIRPreprocessor {
         setFHIRContext(fCtx, httpCtx);
     }
 
+    # Processes a FHIR operation request.
+    #
+    # + fhirResourceType - The FHIR resource type
+    # + fhirOperation - The FHIR operation to be processed
+    # + operationRequestScope - The scope of the operation request
+    # + payload - The payload of the request
+    # + httpRequest - The HTTP request
+    # + httpCtx - The HTTP context
+    # + return - A `r4:FHIRError` if an error occurs during the processing, or `()` otherwise
+    public isolated function processOperation(string fhirResourceType, string fhirOperation,
+            r4:FHIRInteractionLevel operationRequestScope, json|xml? payload, http:Request httpRequest,
+            http:RequestContext httpCtx) returns r4:FHIRError? {
+        log:printDebug(string `Pre-processing FHIR operation : ${fhirOperation}`);
+
+        // Validate main HTTP headers
+        r4:FHIRRequestMimeHeaders clientHeaders = check validateClientRequestHeaders(httpRequest);
+
+        r4:FHIRResourceEntity? resourceEntity = ();
+        map<r4:RequestSearchParameter[]> requestOperationSearchParameters = {};
+
+        // Get operation definitions for the resource type
+        r4:OperationCollection resourceOperationDefinitions = r4:fhirRegistry.getResourceOperations(fhirResourceType);
+
+        if resourceOperationDefinitions.hasKey(fhirOperation) { // Valid operation for the resource type 
+            log:printDebug(string `Processing resource bound operation: ${fhirOperation}`);
+
+            // Get operation definition and config
+            r4:FHIROperationDefinition resourceOperationDefinition = resourceOperationDefinitions.get(fhirOperation);
+            r4:OperationConfig? resourceOperationConfig = self.operationConfigMap.get(fhirOperation);
+
+            map<r4:RequestSearchParameter[]>|r4:FHIRResourceEntity? processRes =
+                    check preProcessOperation(fhirResourceType, fhirOperation, operationRequestScope,
+                    resourceOperationDefinition, resourceOperationConfig, self.operationConfigMap, self.apiConfig,
+                    payload, httpRequest, httpCtx, clientHeaders);
+
+            if processRes is map<r4:RequestSearchParameter[]> { // GET invoked
+                requestOperationSearchParameters = processRes;
+            } else if processRes is r4:FHIRResourceEntity { // POST invoked
+                resourceEntity = processRes;
+            }
+        } else if r4:BASE_RESOURCE_OPERATIONS.hasKey(fhirOperation) { // Base operation (common operation)
+            log:printDebug(string `Processing base operation: ${fhirOperation}`);
+
+            // Get base operation definition and config
+            r4:FHIROperationDefinition baseOperationDefinition = r4:BASE_RESOURCE_OPERATIONS.get(fhirOperation);
+            r4:OperationConfig baseOperationConfig = self.operationConfigMap.get(fhirOperation);
+
+            map<r4:RequestSearchParameter[]>|r4:FHIRResourceEntity? processRes =
+                    check preProcessOperation(fhirResourceType, fhirOperation, operationRequestScope,
+                            baseOperationDefinition, baseOperationConfig, self.operationConfigMap, self.apiConfig,
+                            payload, httpRequest, httpCtx, clientHeaders);
+
+            if processRes is map<r4:RequestSearchParameter[]> {
+                requestOperationSearchParameters = processRes;
+            } else if processRes is r4:FHIRResourceEntity {
+                resourceEntity = processRes;
+            }
+        } else { // Invalid operation for the resource type
+            string message = "Unknown operation";
+            string diagnostic = "Operation \"$" + fhirOperation + "\" is not known for resource type \""
+                    + fhirResourceType + "\". Known and defined operations for \"" + fhirResourceType
+                    + "\" resource: " + self.operationConfigMap.keys().toString() + ".";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                    httpStatusCode = http:STATUS_BAD_REQUEST);
+        }
+
+        // Create interaction
+        readonly & r4:FHIROperationInteraction operationInteraction = {operation: fhirOperation};
+
+        // Create FHIR request
+        r4:FHIRRequest fhirRequest = new (operationInteraction, fhirResourceType,
+            resourceEntity, requestOperationSearchParameters.cloneReadOnly(), clientHeaders.acceptType
+        );
+
+        // Populate JWT information in FHIR context
+        readonly & r4:FHIRSecurity fhirSecurity = check getFHIRSecurity(httpRequest);
+
+        r4:HTTPRequest & readonly request = createHTTPRequestRecord(httpRequest, payload);
+
+        // Create FHIR context
+        r4:FHIRContext fhirCtx = new (fhirRequest, request, fhirSecurity);
+
+        // Set FHIR context inside HTTP context
+        setFHIRContext(fhirCtx, httpCtx);
+    }
+
     isolated function processSearchParameters(string fhirResourceType, http:Request request)
                                                                 returns map<r4:RequestSearchParameter[]>|r4:FHIRError {
         map<r4:RequestSearchParameter[]> processedSearchParams = {};
@@ -550,7 +662,7 @@ public isolated class FHIRPreprocessor {
         return processedSearchParams;
     }
 
-    isolated function processPaginationParams (http:Request request) returns r4:PaginationContext|r4:FHIRError {
+    isolated function processPaginationParams(http:Request request) returns r4:PaginationContext|r4:FHIRError {
         int page = 1;
         int count = self.pageSize;
         if request.getQueryParamValue(PAGE) is string {
@@ -595,6 +707,565 @@ public isolated class FHIRPreprocessor {
         if authzConfig is r4:AuthzConfig {
             _ = check r4:handleSmartSecurity(authzConfig, fhirSecurity, id);
         }
+    }
+}
+
+# Pre-processes a FHIR operation.
+#
+# + fhirResourceType - The FHIR resource type
+# + fhirOperation - The FHIR operation to be pre-processed
+# + operationRequestScope - The scope of the operation request
+# + operationDefinition - The operation definition
+# + operationConfig - The operation configuration
+# + operationConfigMap - The operation configuration map
+# + apiConfig - The API configuration
+# + payload - The payload of the request
+# + httpRequest - The HTTP request
+# + httpCtx - The HTTP context
+# + clientHeaders - The client headers
+# + return - A map of processed request search parameters if the operation is a GET request, a `r4:FHIRResourceEntity` 
+# if the operation is a POST request with a payload, a `r4:FHIRError` if an error occurs during the pre-processing, or 
+# `()` if the operation is a POST request without a payload
+isolated function preProcessOperation(string fhirResourceType, string fhirOperation,
+        r4:FHIRInteractionLevel operationRequestScope, r4:FHIROperationDefinition operationDefinition,
+        r4:OperationConfig? operationConfig, map<r4:OperationConfig> operationConfigMap, r4:ResourceAPIConfig apiConfig,
+        json|xml? payload, http:Request httpRequest, http:RequestContext httpCtx, r4:FHIRRequestMimeHeaders clientHeaders)
+        returns map<r4:RequestSearchParameter[]>|r4:FHIRResourceEntity|r4:FHIRError? {
+    // Validate operation config
+    if operationConfig == () || !operationConfig.active {
+        string message = "Unsupported operation";
+        string diagnostic = "Resource type \"$" + fhirResourceType + "\" does not support operation "
+                + "\"" + fhirOperation + "\". Supported operations for \"" + fhirResourceType + "\" resource: "
+                + extractActiveOperationNames(operationConfigMap).toBalString();
+        return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                httpStatusCode = http:STATUS_BAD_REQUEST);
+    }
+
+    // Validate operation invocation scope
+    string[] operationScopes = getOperationScopes(operationDefinition);
+    if operationScopes.indexOf(operationRequestScope) == () {
+        string message = "Invalid operation scope";
+        string diagnostic = "Operation \"$" + fhirOperation + "\" does not support scope "
+                + "\"" + operationRequestScope + "\". Supported scopes for \"$" + fhirOperation + "\" "
+                + "operation: " + operationScopes.toBalString() + ".";
+        return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                            httpStatusCode = http:STATUS_BAD_REQUEST);
+    }
+
+    // Operation parameter definitions and configs
+    r4:FHIROperationParameterDefinition[] operationParameterDefinitions = operationDefinition.'parameter ?: [];
+    r4:OperationParamConfig[] operationParameterConfigs = operationConfig.parameters ?: [];
+
+    // An operation can be GET or POST invoked
+    if httpRequest.method == http:GET {
+        // Custom pre-processor check
+        r4:OperationPreProcessor? customPreProcessor = operationConfig.preProcessor;
+        if customPreProcessor != () {
+            return check customPreProcessor(operationDefinition, fhirResourceType, httpRequest.getQueryParams(), ());
+        }
+
+        // Only operations that does not affect the state can be invoked using GET
+        if isStateAffectedByOperation(operationDefinition) {
+            string message = "Invalid operation invocation";
+            string diagnostic = "Operation \"$" + fhirOperation + "\" cannot be invoked using HTTP GET "
+                    + "because it affects the state. Please use HTTP POST to invoke this operation.";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                    httpStatusCode = http:STATUS_METHOD_NOT_ALLOWED);
+        }
+
+        // Process operation query parameters
+        map<r4:RequestSearchParameter[]> requestOperationSearchParameters =
+                check processOperationQueryParams(fhirOperation, operationRequestScope,
+                        operationParameterDefinitions, operationParameterConfigs, httpRequest);
+
+        // Validate operation parameter cardinality
+        check validateOperationParamCardinality(fhirOperation, operationParameterConfigs,
+                requestOperationSearchParameters);
+
+        return requestOperationSearchParameters;
+    } else if httpRequest.method == http:POST {
+        // Custom pre-processor check
+        r4:OperationPreProcessor? customPreProcessor = operationConfig.preProcessor;
+        if customPreProcessor != () {
+            return check customPreProcessor(operationDefinition, fhirResourceType, (), payload);
+        }
+
+        // An operation invocation with no payload is valid if the operation has no parameters
+        if payload == () {
+            return;
+        }
+
+        // If there is a payload, it should be a valid Parameters resource
+        // Validate and parse payload
+        anydata|r4:FHIRParseError parsedResource = parser:parse(payload);
+        international401:Parameters|error parsedParametersPayload = parsedResource.ensureType();
+
+        if parsedResource is r4:FHIRParseError || parsedParametersPayload is error {
+            string message = "Invalid operation payload";
+            string diagnostic = "Payload for operation \"$" + fhirOperation + "\" is not a valid \"Parameters\" "
+                        + "resource. Please provide a valid \"Parameters\" resource as the payload.";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                        httpStatusCode = http:STATUS_BAD_REQUEST);
+        }
+
+        // Process operation params of the payload
+        map<international401:ParametersParameter[]> processedParams = check processOperationPayloadParams(fhirOperation,
+                operationRequestScope, operationParameterDefinitions, operationParameterConfigs, parsedParametersPayload);
+
+        // Validate operation parameter cardinality
+        check validateOperationParamCardinality(fhirOperation, operationParameterConfigs, processedParams);
+
+        return new r4:FHIRResourceEntity(parsedResource);
+    } else {
+        string message = "Invalid HTTP method";
+        string diagnostic = "The HTTP method for an operation must be either GET or POST.";
+        return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                httpStatusCode = http:STATUS_BAD_REQUEST);
+    }
+}
+
+# Processes the query parameters of a FHIR operation GET request.
+#
+# + fhirOperation - The FHIR operation
+# + operationRequestScope - The scope of the operation request
+# + operationParamDefinitions - The operation parameter definitions
+# + operationParamConfigs - The operation parameter configurations
+# + httpRequest - The HTTP request from which the query parameters are retrieved
+# + return - A map of processed operation search parameters, or a `r4:FHIRError` if an error occurs during the processing
+isolated function processOperationQueryParams(string fhirOperation,
+        r4:FHIRInteractionLevel operationRequestScope,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions,
+        r4:OperationParamConfig[] operationParamConfigs, http:Request httpRequest)
+    returns map<r4:RequestSearchParameter[]>|r4:FHIRError {
+    log:printDebug(string `Processing GET invoked operation params of operation: ${fhirOperation}`);
+
+    map<r4:RequestSearchParameter[]> processedOperationSearchParams = {};
+    map<string[]?> requestQueryParams = httpRequest.getQueryParams();
+
+    // Process each parameter in the request
+    foreach string originalParamName in requestQueryParams.keys() {
+        string[] paramValues = requestQueryParams.get(originalParamName) ?: [];
+
+        // When an operation parameter has a search type, search modifiers are available
+        // Decode parameter and separate name and modifier
+        r4:RequestQueryParameter queryParam = check r4:decodeSearchParameterKey(originalParamName, paramValues);
+
+        // Process operation parameter
+        check processOperationQueryParam(queryParam, fhirOperation, operationRequestScope,
+                    operationParamDefinitions, operationParamConfigs, processedOperationSearchParams);
+    }
+
+    return processedOperationSearchParams;
+}
+
+# Processes a single query parameter of a FHIR operation GET request.
+#
+# + queryParam - The query parameter to be processed
+# + fhirOperation - The FHIR operation
+# + operationRequestScope - The scope of the operation request
+# + operationParamDefinitions - The operation parameter definitions
+# + operationParamConfigs - The operation parameter configurations
+# + processedOperationSearchParams - The map of processed operation search parameters
+# + return - A `r4:FHIRError` if an error occurs during the processing, or `()` if the processing is successful
+isolated function processOperationQueryParam(r4:RequestQueryParameter queryParam, string fhirOperation,
+        r4:FHIRInteractionLevel operationRequestScope, r4:FHIROperationParameterDefinition[] operationParamDefinitions,
+        r4:OperationParamConfig[] operationParamConfigs, map<r4:RequestSearchParameter[]> processedOperationSearchParams)
+        returns r4:FHIRError? {
+    // Split parameter name and parts
+    string[] paramParts = regexp:split(re `\.`, queryParam.name);
+    string paramName = paramParts[0];
+    string[] remainingParts = paramParts.length() > 1 ? paramParts.slice(1) : [];
+
+    // Get parameter definition
+    r4:FHIROperationParameterDefinition? paramDefinition = getOperationParameterDefinition(paramName,
+            operationParamDefinitions);
+
+    if paramDefinition == () { // Unknown parameter
+        return createUnknownOperationParamError(paramName, fhirOperation, operationParamDefinitions);
+    }
+
+    // Get parameter config
+    r4:OperationParamConfig? paramConfig = getOperationParameterConfig(paramName, operationParamConfigs);
+
+    if paramConfig == () || !paramConfig.active { // Unsupported parameter
+        return createUnsupportedOperationParamError(paramName, fhirOperation, operationParamConfigs);
+    }
+
+    // Validate invocation scope based on config's scope
+    check validateOperationParamScope(fhirOperation, paramConfig, operationRequestScope);
+
+    // Process query parameter as a FHIR search parameter
+    r4:RequestSearchParameter[] searchParams;
+    if isMultiPartOperationParameter(paramDefinition) {
+        // If there are remaining parts, process the part parameter
+        if remainingParts.length() > 0 {
+            searchParams = check processOperationPartQueryParam(fhirOperation, operationRequestScope, queryParam,
+                    remainingParts[0], remainingParts.slice(1), paramDefinition, paramConfig, operationParamDefinitions,
+                    operationParamConfigs);
+        } else { // Multi-part parameter without parts
+            return createMultiPartOperationParamWithoutPartsError(paramDefinition.name, fhirOperation,
+                        operationParamDefinitions);
+        }
+    } else { // Not a multi-part parameter
+        searchParams = check processOperationQueryParamAsSearchParam(queryParam, paramDefinition);
+    }
+
+    processedOperationSearchParams[queryParam.name] = searchParams;
+}
+
+# Processes a part of a multi-part query parameter of a FHIR operation GET request.
+#
+# + fhirOperation - The FHIR operation
+# + operationRequestScope - The scope of the operation request
+# + queryParam - The query parameter to be processed
+# + partParamName - The name of the part parameter
+# + remainingParts - The remaining parts of the multi-part parameter
+# + currentParamDefinition - The current operation parameter definition
+# + currentParamConfig - The current operation parameter configuration
+# + operationParamDefinitions - The operation parameter definitions
+# + operationParamConfigs - The operation parameter configurations
+# + return - An array of processed search parameters, or a `r4:FHIRError` if an error occurs during the processing
+isolated function processOperationPartQueryParam(string fhirOperation, r4:FHIRInteractionLevel operationRequestScope,
+        r4:RequestQueryParameter queryParam, string partParamName, string[] remainingParts,
+        r4:FHIROperationParameterDefinition currentParamDefinition, r4:OperationParamConfig currentParamConfig,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions,
+        r4:OperationParamConfig[] operationParamConfigs) returns r4:RequestSearchParameter[]|r4:FHIRError {
+    // Get part parameter definition
+    r4:FHIROperationParameterDefinition? partParamDefinition =
+                getOperationPartParameterDefinition(partParamName, currentParamDefinition);
+
+    if partParamDefinition == () { // Unknown part parameter
+        return createUnknownOperationParamError(queryParam.name, fhirOperation, operationParamDefinitions);
+    }
+
+    // Get part parameter config
+    r4:OperationParamConfig? partParamConfig = getOperationPartParameterConfig(partParamName, currentParamConfig);
+
+    if partParamConfig == () || !partParamConfig.active { // Unsupported part parameter
+        return createUnsupportedOperationParamError(queryParam.name, fhirOperation, operationParamConfigs);
+    }
+
+    // Validate invocation scope based on config's scope
+    check validateOperationParamScope(fhirOperation, partParamConfig, operationRequestScope);
+
+    // A part parameter can have parts of its own
+    // For an example, see https://hl7.org/fhir/R4/codesystem-operation-find-matches.html
+    if isMultiPartOperationParameter(partParamDefinition) {
+        if remainingParts.length() > 0 {
+            // Process next part parameter
+            return processOperationPartQueryParam(fhirOperation, operationRequestScope, queryParam, remainingParts[0],
+                        remainingParts.slice(1), partParamDefinition, partParamConfig, operationParamDefinitions,
+                        operationParamConfigs);
+        } else { // Multi-part parameter without parts
+            return createMultiPartOperationParamWithoutPartsError(partParamName, fhirOperation,
+                        operationParamDefinitions);
+        }
+    } else {
+        // Process current (last) part parameter as search parameter
+        return check processOperationQueryParamAsSearchParam(queryParam, partParamDefinition);
+    }
+}
+
+# Processes a FHIR operation GET request query parameter as a search parameter.
+#
+# + queryParam - The FHIR operation request query parameter to process
+# + paramDefinition - The definition of the query parameter
+# + return - An array containing the processed search parameters if the processing is successful, 
+# or a `r4:FHIRError` otherwise
+isolated function processOperationQueryParamAsSearchParam(r4:RequestQueryParameter queryParam,
+        r4:FHIROperationParameterDefinition paramDefinition) returns r4:RequestSearchParameter[]|r4:FHIRError {
+    r4:FHIROperationParameterDefinition tmpParamDefinition;
+
+    // FHIR operation parameters are either resources, data types, or search parameters
+    // If the parameter has a 'searchType', it is a search parameter
+    if paramDefinition.searchType != () {
+        tmpParamDefinition = paramDefinition;
+    } else { // Parameter is a data type or resource type
+        string? 'type = paramDefinition.'type;
+
+        // At this point, the parameter should have a type
+        if 'type == () {
+            // This shouldn't happen as the parameter definition should have a type
+            string message = "Unknown parameter type";
+            string diagnostic = "The type of parameter \"" + paramDefinition.name + "\" is unknown. "
+                    + "Therefore, this parameter cannot be processed properly.";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic);
+        }
+
+        // Only primitive types are supported for GET invoked operations.
+        // Try to map the parameter type to a search parameter type
+        r4:FHIRSearchParameterType|r4:FHIRError searchParamType = r4:primitiveTypeToSearchParamType('type);
+        if searchParamType is r4:FHIRError { // Parameter type is not a primitive type
+            string message = "Invalid operation invocation";
+            string diagnostic = "Operation parameter \"" + queryParam.name + "\" cannot be invoked using "
+                    + "HTTP GET method because its type \"" + 'type + "\" is not a primitive type. "
+                    + "Please use HTTP POST method instead.";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                    httpStatusCode = http:STATUS_METHOD_NOT_ALLOWED);
+        }
+
+        // New operation parameter definition including the mapped type as the search type
+        r4:FHIROperationParameterDefinition newDefinition = {
+            name: paramDefinition.name,
+            use: paramDefinition.use,
+            min: paramDefinition.min,
+            max: paramDefinition.max,
+            searchType: searchParamType
+        };
+
+        tmpParamDefinition = newDefinition;
+    }
+
+    // Create search params
+    r4:RequestSearchParameter[] searchParams = [];
+
+    foreach string value in queryParam.values {
+        r4:RequestSearchParameter searchParam =
+                    check r4:createRequestSearchParameter(tmpParamDefinition, queryParam.modifier, value);
+        searchParams.push(searchParam);
+    }
+
+    return searchParams;
+}
+
+# Processes payload parameters of a POST invoked FHIR operation.
+#
+# + fhirOperation - The FHIR operation
+# + operationRequestScope - The request scope of the operation
+# + operationParamDefinitions - The parameter definitions for the operation
+# + operationParamConfigs - The parameter configurations for the operation
+# + parsedParametersPayload - The parsed parameters payload to process
+# + return - A map of processed parameters, or a `r4:FHIRError` if a parameter cannot be processed
+isolated function processOperationPayloadParams(string fhirOperation, r4:FHIRInteractionLevel operationRequestScope,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions, r4:OperationParamConfig[] operationParamConfigs,
+        international401:Parameters parsedParametersPayload) returns map<international401:ParametersParameter[]>|r4:FHIRError {
+    log:printDebug(string `Processing POST invoked operation params of operation: ${fhirOperation}`);
+    map<international401:ParametersParameter[]> processedOperationParams = {};
+
+    international401:ParametersParameter[]? parameters = parsedParametersPayload.'parameter;
+    if parameters != () {
+        foreach international401:ParametersParameter 'parameter in parameters {
+            check validateAndProcessOperationPayloadParam(fhirOperation, 'parameter, operationRequestScope,
+            operationParamDefinitions, operationParamConfigs, processedOperationParams);
+        }
+    }
+
+    return processedOperationParams;
+}
+
+# Validates and processes a payload parameter of a POST invoked FHIR operation.
+#
+# + fhirOperation - The FHIR operation
+# + 'parameter - The parameter to validate and process
+# + operationRequestScope - The request scope of the operation
+# + operationParamDefinitions - The parameter definitions for the operation
+# + operationParamConfigs - The parameter configurations for the operation
+# + processedOperationParams - The map of processed parameters
+# + return - A `r4:FHIRError` if the parameter cannot be processed, nil otherwise
+isolated function validateAndProcessOperationPayloadParam(string fhirOperation,
+        international401:ParametersParameter 'parameter, r4:FHIRInteractionLevel operationRequestScope,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions, r4:OperationParamConfig[] operationParamConfigs,
+        map<international401:ParametersParameter[]> processedOperationParams) returns r4:FHIRError? {
+    // Get parameter definition and config
+    r4:FHIROperationParameterDefinition? parameterDefinition = getOperationParameterDefinition('parameter.name,
+            operationParamDefinitions);
+    r4:OperationParamConfig? parameterConfig = getOperationParameterConfig('parameter.name, operationParamConfigs);
+
+    return processOperationPayloadParam(fhirOperation, 'parameter, 'parameter.name, operationRequestScope,
+            parameterDefinition, parameterConfig, processedOperationParams, operationParamDefinitions,
+            operationParamConfigs);
+}
+
+# Validates and processes a part parameter of a POST invoked FHIR operation payload.
+#
+# + fhirOperation - The FHIR operation to process
+# + 'parameter - The part parameter to validate and process
+# + fullParamName - The full name of the parameter
+# + operationRequestScope - The request scope of the operation
+# + currentParamDefinition - The current parameter definition for the operation
+# + currentParamConfig - The current parameter configuration for the operation
+# + operationParamDefinitions - The parameter definitions for the operation
+# + operationParamConfigs - The parameter configurations for the operation
+# + processedOperationParams - The map of processed parameters
+# + return - A map of processed parameters, or a `r4:FHIRError` if the part parameter cannot be processed
+isolated function validateAndProcessOperationPayloadPartParam(string fhirOperation,
+        international401:ParametersParameter 'parameter, string fullParamName, r4:FHIRInteractionLevel operationRequestScope,
+        r4:FHIROperationParameterDefinition currentParamDefinition, r4:OperationParamConfig currentParamConfig,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions, r4:OperationParamConfig[] operationParamConfigs,
+        map<international401:ParametersParameter[]> processedOperationParams) returns r4:FHIRError? {
+    // Get part parameter definition and config
+    r4:FHIROperationParameterDefinition? partParameterDefinition = getOperationPartParameterDefinition('parameter.name,
+            currentParamDefinition);
+    r4:OperationParamConfig? partParameterConfig = getOperationPartParameterConfig('parameter.name, currentParamConfig);
+
+    return processOperationPayloadParam(fhirOperation, 'parameter, fullParamName, operationRequestScope,
+            partParameterDefinition, partParameterConfig, processedOperationParams, operationParamDefinitions,
+            operationParamConfigs);
+}
+
+# Processes a payload parameter of a FHIR operation.
+#
+# + fhirOperation - The FHIR operation
+# + 'parameter - The payload parameter to process
+# + paramName - The name of the payload parameter
+# + operationRequestScope - The request scope of the operation
+# + parameterDefinition - The definition of the payload parameter
+# + parameterConfig - The configuration of the payload parameter
+# + processedOperationParams - The map of processed parameters
+# + operationParamDefinitions - The parameter definitions for the operation
+# + operationParamConfigs - The parameter configurations for the operation
+# + return - A `r4:FHIRError` if the parameter cannot be processed, nil otherwise
+isolated function processOperationPayloadParam(string fhirOperation, international401:ParametersParameter 'parameter,
+        string paramName, r4:FHIRInteractionLevel operationRequestScope,
+        r4:FHIROperationParameterDefinition? parameterDefinition, r4:OperationParamConfig? parameterConfig,
+        map<international401:ParametersParameter[]> processedOperationParams,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions,
+        r4:OperationParamConfig[] operationParamConfigs) returns r4:FHIRError? {
+
+    if parameterDefinition == () { // Unknown parameter
+        return createUnknownOperationParamError(paramName, fhirOperation, operationParamDefinitions);
+    }
+
+    if parameterConfig == () || !parameterConfig.active { // Unsupported parameter
+        return createUnsupportedOperationParamError(paramName, fhirOperation, operationParamConfigs);
+    }
+
+    // Validate parameter invocation scope
+    check validateOperationParamScope(fhirOperation, parameterConfig, operationRequestScope);
+
+    if isMultiPartOperationParameter(parameterDefinition) {
+        international401:ParametersParameter[]? paramParts = 'parameter.part;
+        if paramParts != () {
+            foreach international401:ParametersParameter partParam in paramParts {
+                check validateAndProcessOperationPayloadPartParam(fhirOperation, partParam,
+                        string `${paramName}.${partParam.name}`, operationRequestScope, parameterDefinition,
+                        parameterConfig, operationParamDefinitions, operationParamConfigs, processedOperationParams);
+            }
+        } else { // Multi-part parameter invocation without parts
+            return createMultiPartOperationParamWithoutPartsError(paramName, fhirOperation, operationParamDefinitions);
+        }
+    } else {
+        if processedOperationParams.hasKey(paramName) {
+            processedOperationParams.get(paramName).push('parameter);
+        } else {
+            processedOperationParams[paramName] = ['parameter];
+        }
+    }
+}
+
+# Validates the invocation scope of a FHIR operation parameter.
+#
+# + fhirOperation - The FHIR operation
+# + paramConfig - The configuration of the parameter to validate
+# + requestOperationScope - The request operation scope
+# + return - A `r4:FHIRError` if the parameter does not support the request operation scope, nil otherwise
+isolated function validateOperationParamScope(string fhirOperation, r4:OperationParamConfig paramConfig,
+        r4:FHIRInteractionLevel requestOperationScope) returns r4:FHIRError? {
+    // 'scope' element is not defined for R4 operation definitions. Therefore, we validate scope 
+    // based on the API config. If a scope is not defined in the config, it is assumed that the 
+    // parameter can be invoked at all scopes/levels (system, type, instance).
+    r4:FHIRInteractionLevel[]? supportedScopes = paramConfig.scopes;
+    if supportedScopes != () && supportedScopes.indexOf(requestOperationScope) == () {
+        string message = "Invalid operation parameter scope";
+        string diagnostic = "Parameter \"" + paramConfig.name + "\" of operation \"$" + fhirOperation + "\" "
+                + "does not support scope \"" + requestOperationScope + "\". Supported scopes for operation parameter "
+                + "\"" + paramConfig.name + "\": " + supportedScopes.toBalString() + ".";
+        return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                httpStatusCode = http:STATUS_BAD_REQUEST);
+    }
+}
+
+# Validates the cardinality of FHIR operation parameters.
+#
+# + fhirOperation - The FHIR operation
+# + operationParamConfigs - The parameter configurations of the FHIR operation
+# + parameters - The processed parameters of the FHIR operation
+# + multiPartParam - The name of the multi-part parameter
+# + return - A `r4:FHIRError` if the cardinality of a parameter is not valid, nil otherwise
+isolated function validateOperationParamCardinality(string fhirOperation,
+        r4:OperationParamConfig[] operationParamConfigs,
+        map<r4:RequestSearchParameter[]>|map<international401:ParametersParameter[]> parameters,
+        string? multiPartParam = ()) returns r4:FHIRError? {
+    // Cardinality could vary based on the parameter's scope. However, as the 'scope' property 
+    // is not defined in R4 operation definitions, we validate the cardinality defined in the API config.
+    foreach r4:OperationParamConfig paramConfig in operationParamConfigs {
+        // Get cardinalities
+        var [minCardinality, maxCardinality] = getOperationParamCardinalities(paramConfig);
+
+        // Get parameter parts
+        r4:OperationParamConfig[]? partParamConfigs = paramConfig.parts;
+        string paramName = multiPartParam != () ? string `${multiPartParam}.${paramConfig.name}` : paramConfig.name;
+
+        if partParamConfigs != () { // Multi-part parameter
+            return check validateOperationParamCardinality(fhirOperation, partParamConfigs, parameters, paramName);
+        }
+
+        int noOfProcessedParams = parameters.hasKey(paramName) ? parameters.get(paramName).length() : 0;
+
+        // Check min cardinality
+        if minCardinality != 0 && noOfProcessedParams < minCardinality {
+            string message = "Too few operation parameters";
+            string diagnostic = "The parameter \"" + paramName + "\" of operation \"$" + fhirOperation + "\" is "
+                    + "expected to be present at least " + minCardinality.toString() + " times, but "
+                    + noOfProcessedParams.toString() + " occurrences were found.";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                    httpStatusCode = http:STATUS_BAD_REQUEST);
+        }
+
+        // Check max cardinality
+        if maxCardinality != -1 && noOfProcessedParams > maxCardinality {
+            string message = "Too many operation parameters";
+            string diagnostic = "The parameter \"" + paramName + "\" of operation \"$" + fhirOperation + "\" is "
+                    + "expected to be present at most " + maxCardinality.toString() + " times, but "
+                    + noOfProcessedParams.toString() + " occurrences were found.";
+            return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+                    httpStatusCode = http:STATUS_BAD_REQUEST);
+        }
+    }
+}
+
+# Retrieves the cardinalities of a parameter of a FHIR operation.
+#
+# + 'parameter - The FHIR operation parameter definition or configuration to retrieve the cardinalities from
+# + return - A tuple containing the minimum and maximum cardinalities of the parameter
+isolated function getOperationParamCardinalities(r4:FHIROperationParameterDefinition|r4:OperationParamConfig 'parameter)
+        returns [int, int] {
+    int minCardinality = 'parameter.min ?: 0;
+    int|error maxCardinality = int:fromString('parameter.max ?: "-1");
+    if maxCardinality is error {
+        return [minCardinality, -1];
+    }
+    return [minCardinality, maxCardinality];
+}
+
+# Checks if a FHIR operation affects the state.
+#
+# + operationDefinition - The FHIR operation definition to check
+# + return - A boolean indicating whether the operation affects the state of a resource
+isolated function isStateAffectedByOperation(r4:FHIROperationDefinition operationDefinition) returns boolean =>
+    operationDefinition.affectsState ?: false;
+
+# Checks if a parameter name follows the format of a FHIR operation part parameter.
+#
+# + paramName - The parameter name to check
+# + return - A boolean indicating whether the parameter name follows the format of a FHIR operation part parameter
+isolated function isOperationPartParamFormat(string paramName) returns boolean {
+    // Operation part parameters are GET invoked in the format: <paramName>.<partName>...
+    // For example, a part parameter invocation could look like: param.part1.subpart1
+    return regexp:isFullMatch(re `^\w+\.\w+(?:\.\w+)*$`, paramName);
+}
+
+# Checks if an operation parameter is a multi-part parameter.
+#
+# + operationParameter - The operation parameter to check
+# + return - A boolean indicating whether the operation parameter is a multi-part parameter
+isolated function isMultiPartOperationParameter(r4:FHIROperationParameterDefinition
+        |r4:OperationParamConfig operationParameter) returns boolean {
+    if operationParameter is r4:FHIROperationParameterDefinition {
+        // A multi-part parameter does not have a type, but has parts
+        return operationParameter.'type == () && operationParameter.part != ();
+    } else {
+        return operationParameter.parts != ();
     }
 }
 
@@ -884,4 +1555,189 @@ isolated function createHTTPRequestRecord(http:Request request, json|xml? payloa
         headers: headers.cloneReadOnly(),
         payload: payload.cloneReadOnly()
     };
+}
+
+# Retrieves the operation parameter definition for a given parameter name.
+#
+# + paramName - The name of the operation parameter to find
+# + parameterDefinitions - The parameter definitions to search
+# + return - The matching parameter definition if found, nil otherwise
+isolated function getOperationParameterDefinition(string paramName,
+        r4:FHIROperationParameterDefinition[] parameterDefinitions) returns r4:FHIROperationParameterDefinition? {
+    foreach r4:FHIROperationParameterDefinition paramDef in parameterDefinitions {
+        if paramDef.name == paramName {
+            return paramDef;
+        }
+    }
+    return;
+}
+
+# Retrieves the operation part parameter definition for a given part parameter name.
+#
+# + partParamName - The name of the part parameter to find
+# + multiPartParamDefinition - The multi-part operation parameter definition to search
+# + return - The matching parameter definition if found, nil otherwise
+isolated function getOperationPartParameterDefinition(string partParamName,
+        r4:FHIROperationParameterDefinition multiPartParamDefinition) returns r4:FHIROperationParameterDefinition? {
+    r4:FHIROperationParameterDefinition[]? parts = multiPartParamDefinition.part;
+    return parts != () ? getOperationParameterDefinition(partParamName, parts) : ();
+}
+
+# Retrieves the operation parameter configuration for a given parameter name.
+#
+# + paramName - The name of the operation parameter to find
+# + operationParameterConfigs - The operation parameter configs to search
+# + return - The matching operation parameter config if found, nil otherwise
+isolated function getOperationParameterConfig(string paramName,
+        r4:OperationParamConfig[] operationParameterConfigs) returns r4:OperationParamConfig? {
+    foreach r4:OperationParamConfig paramConfig in operationParameterConfigs {
+        if paramConfig.name == paramName {
+            return paramConfig;
+        }
+    }
+    return;
+}
+
+# Retrieves the operation part parameter configuration for a given part parameter name.
+#
+# + partParamName - The name of the part parameter to find
+# + multiPartParamConfig - The multi-part operation parameter configuration to search
+# + return - The matching operation parameter config if found, nil otherwise
+isolated function getOperationPartParameterConfig(string partParamName,
+        r4:OperationParamConfig multiPartParamConfig) returns r4:OperationParamConfig? {
+    r4:OperationParamConfig[]? parts = multiPartParamConfig.parts;
+    return parts != () ? getOperationParameterConfig(partParamName, parts) : ();
+}
+
+# Extracts the names of active operations.
+#
+# + operationConfigMap - The operation configuration map to extract active operation names from
+# + return - An array containing the names of active operations
+isolated function extractActiveOperationNames(map<r4:OperationConfig> operationConfigMap) returns string[] {
+    string[] activeOperations = [];
+    foreach r4:OperationConfig operationConfig in operationConfigMap {
+        if operationConfig.active {
+            activeOperations.push(operationConfig.name);
+        }
+    }
+    return activeOperations;
+}
+
+# Extracts the names of known operation input parameters.
+#
+# + paramDefinitions - The parameter definitions to extract input parameter names from
+# + multiPartParam - The name of the multi-part parameter that the input parameters are part of, if any
+# + return - An array containing the names of known input parameters
+isolated function extractKnownOperationInParamNames(r4:FHIROperationParameterDefinition[] paramDefinitions,
+        string? multiPartParam = ()) returns string[] {
+    string[] knownParameters = [];
+    foreach r4:FHIROperationParameterDefinition paramDefinition in paramDefinitions {
+        if paramDefinition.use == r4:INPUT { // Only input parameters
+            string paramName = multiPartParam != () ? string `${multiPartParam}.${paramDefinition.name}` : paramDefinition.name;
+            if isMultiPartOperationParameter(paramDefinition) {
+                // Check part parameters
+                r4:FHIROperationParameterDefinition[]? partParamDefinitions = paramDefinition.part;
+                if partParamDefinitions != () {
+                    string[] partParams = extractKnownOperationInParamNames(partParamDefinitions, paramName);
+                    knownParameters.push(...partParams);
+                }
+            } else {
+                knownParameters.push(paramName);
+            }
+        }
+    }
+    return knownParameters;
+}
+
+# Extracts the names of active operation input parameters.
+#
+# + paramConfigs - The parameter configurations to extract input parameter names from
+# + multiPartParam - The name of the multi-part parameter that the input parameters are part of, if any
+# + return - An array containing the names of known input parameters
+isolated function extractActiveOperationInParamNames(r4:OperationParamConfig[] paramConfigs,
+        string? multiPartParam = ()) returns string[] {
+    string[] activeParameters = [];
+    foreach r4:OperationParamConfig paramConfig in paramConfigs {
+        if paramConfig.active {
+            string paramName = multiPartParam != () ? string `${multiPartParam}.${paramConfig.name}` : paramConfig.name;
+            if isMultiPartOperationParameter(paramConfig) { // Multi-part parameter
+                // Check part parameters
+                r4:OperationParamConfig[]? partParamConfigs = paramConfig.parts;
+                if partParamConfigs != () {
+                    string[] partParams = extractActiveOperationInParamNames(partParamConfigs, paramName);
+                    activeParameters.push(...partParams);
+                }
+            } else {
+                activeParameters.push(paramName);
+            }
+        }
+    }
+    return activeParameters;
+}
+
+# Retrieves the scopes of a FHIR operation definition.
+#
+# + operationDefinition - The FHIR operation definition to extract scopes from.
+# + return - An array of the FHIR interaction scopes of the operation definition.
+isolated function getOperationScopes(r4:FHIROperationDefinition operationDefinition) returns string[] {
+    string[] scopes = [];
+    if operationDefinition.systemLevel {
+        scopes.push(r4:FHIR_INTERACTION_SYSTEM);
+    }
+    if operationDefinition.typeLevel {
+        scopes.push(r4:FHIR_INTERACTION_TYPE);
+    }
+    if operationDefinition.instanceLevel {
+        scopes.push(r4:FHIR_INTERACTION_INSTANCE);
+    }
+    return scopes;
+}
+
+# Creates a `r4:FHIRError` for an unknown operation parameter.
+#
+# + paramName - The name of the unknown operation parameter
+# + fhirOperation - The FHIR operation that the unknown parameter was part of
+# + operationParamDefinitions - The operation parameter definitions for the FHIR operation
+# + return - The created `r4:FHIRError`
+isolated function createUnknownOperationParamError(string paramName, string fhirOperation,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions) returns r4:FHIRError {
+    string message = "Unknown operation parameter";
+    string diagnostic = "Unknown parameter \"" + paramName + "\" for operation "
+            + "\"$" + fhirOperation + "\". Known parameters for \"$" + fhirOperation + "\" operation: "
+            + extractKnownOperationInParamNames(operationParamDefinitions).toBalString() + ".";
+    return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+            httpStatusCode = http:STATUS_BAD_REQUEST);
+}
+
+# Creates a `r4:FHIRError` for an unsupported operation parameter.
+#
+# + paramName - The name of the unsupported operation parameter
+# + fhirOperation - The FHIR operation that the unsupported parameter was part of
+# + operationParamConfigs - The operation parameter configurations for the FHIR operation
+# + return - The created `r4:FHIRError`
+isolated function createUnsupportedOperationParamError(string paramName, string fhirOperation,
+        r4:OperationParamConfig[] operationParamConfigs) returns r4:FHIRError {
+    string message = "Unsupported operation parameter";
+    string diagnostic = "Operation \"$" + fhirOperation + "\" does not support parameter \""
+            + paramName + "\". Supported parameters for \"$" + fhirOperation + "\" operation: "
+            + extractActiveOperationInParamNames(operationParamConfigs).toBalString() + ".";
+    return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+            httpStatusCode = http:STATUS_BAD_REQUEST);
+}
+
+# Creates a `r4:FHIRError` for a multi-part operation parameter that is missing its parts.
+#
+# + paramName - The name of the multi-part operation parameter that is missing its parts
+# + fhirOperation - The FHIR operation that the multi-part parameter was part of
+# + operationParamDefinitions - The operation parameter definitions for the FHIR operation
+# + return - The created `r4:FHIRError`
+isolated function createMultiPartOperationParamWithoutPartsError(string paramName, string fhirOperation,
+        r4:FHIROperationParameterDefinition[] operationParamDefinitions) returns r4:FHIRError {
+    string message = "Invalid operation invocation";
+    string diagnostic = "Multi-part parameter \"" + paramName + "\" requires its parts for operation \"$"
+        + fhirOperation + "\". Please include all necessary parts for the multi-part parameter. "
+        + "Known in parameters for \"$" + fhirOperation + "\" operation: "
+        + extractKnownOperationInParamNames(operationParamDefinitions).toBalString() + ".";
+    return r4:createFHIRError(message, r4:ERROR, r4:PROCESSING, diagnostic = diagnostic,
+            httpStatusCode = http:STATUS_BAD_REQUEST);
 }

--- a/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
@@ -1,19 +1,15 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
-
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at
-
 // http://www.apache.org/licenses/LICENSE-2.0
-
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/http;
 import ballerina/lang.regexp;
 import ballerinax/health.fhir.r4;
@@ -38,7 +34,29 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
                 boolean hasPathParam = isHavingPathParam(resourceMethod);
                 any|error executeResourceResult = ();
                 r4:FHIRContext fhirContext;
-                if hasPathParam {
+                if isOperationPath(paths) {
+                    string fhirResource = apiConfig.resourceType;
+                    string operation = paths[path.length() - 1].substring(1);
+                    r4:FHIRInteractionLevel operationScope = getRequestOperationScope(operation, fhirResource, paths);
+                    if hasPathParam { // Instance level operation
+                        string id = paths[paths.length() - 2];
+                        r4:FHIRError? processOperation = self.preprocessor.processOperation(fhirResource,
+                                operation, operationScope, (), req, ctx);
+                        if processOperation is error {
+                            return processOperation;
+                        }
+                        fhirContext = check r4:getFHIRContext(ctx);
+                        executeResourceResult = executeWithID(id, fhirContext, fhirService, resourceMethod);
+                    } else { // System or Type level operation
+                        r4:FHIRError? processOperation =
+                                self.preprocessor.processOperation(fhirResource, operation, operationScope, (), req, ctx);
+                        if processOperation is error {
+                            return processOperation;
+                        }
+                        fhirContext = check r4:getFHIRContext(ctx);
+                        executeResourceResult = executeWithNoParam(fhirContext, fhirService, resourceMethod);
+                    }
+                } else if hasPathParam {
                     // can be any of read, vread, instance history
                     if (paths.length() >= 1 && paths[paths.length() - 1] == HISTORY) {
                         // instance history
@@ -126,34 +144,71 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
             string[] paths = getRequestPaths(req.rawPath);
             Service fhirService = self.holder.getFhirServiceFromHolder();
             handle? resourceMethod = getResourceMethod(fhirService, servicePath, paths, http:HTTP_POST);
-            json|http:ClientError payload = req.getJsonPayload();
-            if payload is json {
-                if resourceMethod is handle {
-                    string fhirResource = apiConfig.resourceType;
+            json|http:NoContentError|http:ClientError payload = req.getJsonPayload();
+
+            any|error executeResourceResult = ();
+            string fhirResource = apiConfig.resourceType;
+            r4:FHIRContext fhirContext;
+
+            if resourceMethod is handle {
+                if isOperationPath(paths) { // An operation
+                    if payload is json || payload is http:NoContentError {
+                        // An operation with no parameters but affects the state is invoked using an empty body
+                        json? operationPayload = payload is http:NoContentError ? () : payload;
+                        string operation = paths[path.length() - 1].substring(1);
+                        r4:FHIRInteractionLevel operationScope = getRequestOperationScope(operation,
+                                fhirResource, paths);
+                        if isHavingPathParam(resourceMethod) { // Instance level operation 
+                            string id = paths[paths.length() - 2];
+                            r4:FHIRError? processOperation = self.preprocessor.processOperation(fhirResource,
+                                operation, operationScope, operationPayload, req, ctx);
+                            if processOperation is error {
+                                return processOperation;
+                            }
+                            fhirContext = check r4:getFHIRContext(ctx);
+                            executeResourceResult = executeWithIDAndPayload(id, operationPayload, fhirContext,
+                                    fhirService, resourceMethod);
+                        } else { // System or Type level operation
+                            r4:FHIRError? processOperation = self.preprocessor.processOperation(fhirResource,
+                                operation, operationScope, operationPayload, req, ctx);
+                            if processOperation is error {
+                                return processOperation;
+                            }
+                            fhirContext = check r4:getFHIRContext(ctx);
+                            executeResourceResult = executeWithPayload(operationPayload, fhirContext,
+                                    fhirService, resourceMethod);
+                        }
+                    } else {
+                        return r4:createFHIRError(string `Invalid operation payload`, r4:CODE_SEVERITY_ERROR,
+                                r4:TRANSIENT, httpStatusCode = http:STATUS_BAD_REQUEST);
+                    }
+                } else if payload is json { // Create interaction
                     r4:FHIRError? processCreate = self.preprocessor.processCreate(fhirResource, payload, req, ctx);
                     if processCreate is r4:FHIRError {
                         return processCreate;
                     }
-                    r4:FHIRContext fhirContext = check r4:getFHIRContext(ctx);
-                    any|error executeResourceResult = executeWithPayload(payload, fhirContext, fhirService, resourceMethod);
-                    if (executeResourceResult is error) {
-                        fhirContext.setInErrorState(true);
-                        fhirContext.setErrorCode(r4:getErrorCode(executeResourceResult));
-                        return r4:handleErrorResponse(executeResourceResult);
-                    }
-                    if executeResourceResult is r4:DomainResource {
-                        string? createdId = executeResourceResult.id;
-                        if createdId is string {
-                            string location = string `${fhirResource}/${createdId}`;
-                            fhirContext.setProperty(r4:LOCATION_HEADER_PROP_NAME, location);
-                        }
-                    }
-                    return executeResourceResult;
+                    fhirContext = check r4:getFHIRContext(ctx);
+                    executeResourceResult = executeWithPayload(payload, fhirContext, fhirService, resourceMethod);
                 } else {
-                    return r4:createFHIRError(string `Path not found: ${req.extraPathInfo}`, r4:CODE_SEVERITY_ERROR, r4:TRANSIENT, httpStatusCode = http:STATUS_NOT_FOUND);
+                    return r4:createFHIRError(string `Invalid payload`, r4:CODE_SEVERITY_ERROR, r4:TRANSIENT,
+                        httpStatusCode = http:STATUS_BAD_REQUEST);
                 }
+                if executeResourceResult is error {
+                    fhirContext.setInErrorState(true);
+                    fhirContext.setErrorCode(r4:getErrorCode(executeResourceResult));
+                    return r4:handleErrorResponse(executeResourceResult);
+                }
+                if executeResourceResult is r4:DomainResource {
+                    string? createdId = executeResourceResult.id;
+                    if createdId is string {
+                        string location = string `${fhirResource}/${createdId}`;
+                        fhirContext.setProperty(r4:LOCATION_HEADER_PROP_NAME, location);
+                    }
+                }
+                return executeResourceResult;
             } else {
-                return r4:createFHIRError(string `Invalid payload`, r4:CODE_SEVERITY_ERROR, r4:TRANSIENT, httpStatusCode = http:STATUS_BAD_REQUEST);
+                return r4:createFHIRError(string `Path not found: ${req.extraPathInfo}`, r4:CODE_SEVERITY_ERROR,
+                        r4:TRANSIENT, httpStatusCode = http:STATUS_NOT_FOUND);
             }
         }
 
@@ -255,4 +310,31 @@ isolated function getRequestPaths(string path) returns string[] {
     _ = paths.remove(0);
     _ = paths[0] == "" ? paths.remove(0) : [];
     return paths;
+}
+
+# Checks if paths represents an operation path.
+#
+# + paths - An paths to check
+# + return - A boolean indicating whether the paths represent an operation path
+isolated function isOperationPath(string[] paths) returns boolean
+    => paths.length() > 0 && paths[paths.length() - 1].startsWith("$");
+
+# Determines the scope of a FHIR operation request.
+#
+# + operation - The FHIR operation
+# + resourceType - The resource type involved in the operation
+# + paths - An array of paths involved in the operation
+# + return - The scope of the operation request
+isolated function getRequestOperationScope(string operation, string resourceType,
+        string[] paths) returns r4:FHIRInteractionLevel {
+    int? resourceTypeIndex = paths.indexOf(resourceType);
+
+    if resourceTypeIndex is () { // No resource type in the path - System level
+        return r4:FHIR_INTERACTION_SYSTEM;
+    } else if resourceTypeIndex < paths.length() - 1 &&
+            (paths[resourceTypeIndex + 1] == string `$${operation}`) { // Type level
+        return r4:FHIR_INTERACTION_TYPE;
+    } else { // Instance level
+        return r4:FHIR_INTERACTION_INSTANCE;
+    }
 }

--- a/fhirr4/ballerina/src/main/resources/fhirservice/tests/operations_test.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/tests/operations_test.bal
@@ -1,0 +1,306 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/test;
+import ballerinax/health.fhir.r4;
+import ballerinax/health.fhir.r4.international401;
+import ballerinax/health.fhir.r4.parser;
+
+Listener fhirOperationsListener = check new (9295, operationsApiConfig);
+http:Client fhirOperationsClient = check new ("http://localhost:9295/fhir/r4");
+
+@test:BeforeGroups {value: ["Operations"]}
+function startOperationsService() returns error? {
+    check fhirOperationsListener.attach(fhirOperationsService);
+    check fhirOperationsListener.'start();
+    log:printInfo("FHIR operations test service has started");
+}
+
+@test:Config {groups: ["Operations"]}
+function testValidGetInvokedOperation() returns error? {
+    international401:Parameters|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?url=http://hl7.org/fhir/");
+    test:assertTrue(response is international401:Parameters);
+}
+
+@test:Config {groups: ["Operations"]}
+function testValidGetInvokedBaseOperation() returns error? {
+    // The operation '$meta' is a base operation for all resource types
+    r4:Meta|ServiceTestError? response = check fhirOperationsClient->get("/ConceptMap/$meta");
+    test:assertTrue(response is r4:Meta);
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperation() returns error? {
+    // The operations '$find-matches' is not a valid operation for the 'ConceptMap' resource type
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$find-matches?system=http://hl7.org/fhir/composition-status");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithUnsupportedOperation() returns error? {
+    // The operation '$closure' is not supported by the API
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/$closure?name=patient-problems");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Unsupported operation"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithInvalidScope() returns error? {
+    // The '$translate' operation is not allowed in the system scope
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/$translate?url=http://hl7.org/fhir/");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Invalid operation scope"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithTooFewParams() returns error? {
+    // The mandatory param 'url' defined in API config is missing in this request
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?dependency.element=http://hl7.org/fhir/");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Too few operation parameters"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithTooManyParams() returns error? {
+    // The operation parameter 'system' count exceeds the limit defined in the API config
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/23224/$translate?url=http://hl7.org/fhir/&system=http://hl7.org/fhir/&system=http://hl7.org/fhir/&system=http://hl7.org/fhir/");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Too many operation parameters"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithInvalidParam() returns error? {
+    // The param 'codeA' is not a valid param of the '$translate' operation
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?url=http://hl7.org/fhir/&codeA=365786009");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Unknown operation parameter"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testValidGetInvokedOperationWithUnsupportedParam() returns error? {
+    // The param 'version' is unsupported for the '$translate' operation
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?url=http://hl7.org/fhir/&version=1");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Unsupported operation parameter"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithInvalidParamScope() returns error? {
+    // The 'system' parameter is only supported at the instance level as per the API configuration, not at the type level
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?url=http://hl7.org/fhir/&version=1&system=http://hl7.org/fhir/composition-status");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Invalid operation parameter scope"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithNonPrimitiveParam() returns error? {
+    // The 'conceptMap' parameter is a resource type, not a primitive type
+    // Therefore, it cannot be used using an HTTP GET method
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?url=http://hl7.org/fhir/&conceptMap={}");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 405);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Invalid operation invocation"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testValidGetInvokedOperationWithMultiPartParam() returns error? {
+    international401:Parameters|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?url=http://hl7.org/fhir/&dependency.element=http://hl7.org/fhir/");
+    test:assertTrue(response is international401:Parameters);
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidGetInvokedOperationWithMultiPartParamWithoutParts() returns error? {
+    // The 'dependency' parameter is a multi-part parameter and it should be invoked with its parts
+    http:Response|ServiceTestError response =
+            check fhirOperationsClient->get("/ConceptMap/$translate?dependency={}");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Invalid operation invocation"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:Config {groups: ["Operations"]}
+function testValidPostInvokedOperation() returns error? {
+    json payload = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "url",
+                "valueUri": "http://hl7.org/fhir/"
+            },
+            {
+                "name": "dependency",
+                "part": [
+                    {
+                        "name": "element",
+                        "valueUri": "http://hl7.org/fhir/"
+                    }
+                ]
+            }
+        ]
+    };
+    international401:Parameters|ServiceTestError response = check fhirOperationsClient->post("/ConceptMap/$translate",
+            message = payload, mediaType = r4:FHIR_MIME_TYPE_JSON);
+    test:assertTrue(response is international401:Parameters);
+}
+
+@test:Config {groups: ["Operations"]}
+function testInvalidPostInvokedOperationWithInvalidPayload() returns error? {
+    json invalidPayload = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "invalidParameter",
+                "invalidValue": "someInvalidValue"
+            }
+        ]
+    };
+    http:Response|ServiceTestError response = check fhirOperationsClient->post("/ConceptMap/$translate",
+            message = invalidPayload, mediaType = r4:FHIR_MIME_TYPE_JSON);
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        string|error diagnostic = extractIssueTextFromOperationOutcomeResponse(response);
+        if diagnostic is string {
+            test:assertTrue(diagnostic.startsWith("Invalid operation payload"));
+        } else {
+            test:assertFail(diagnostic.message());
+        }
+    } else {
+        test:assertFail("Error in service invocation");
+    }
+}
+
+@test:AfterGroups {value: ["Operations"]}
+function stopOperationsService() returns error? {
+    check fhirOperationsListener.gracefulStop();
+    log:printInfo("FHIR operations test service has stopped");
+}
+
+// Helper function to extract the issue text from an operation outcome response
+function extractIssueTextFromOperationOutcomeResponse(http:Response response) returns string|error {
+    json operationOutcome = check response.getJsonPayload();
+    anydata operationOutcomeStruct = check parser:parse(operationOutcome);
+    if operationOutcomeStruct is r4:OperationOutcome {
+        r4:CodeableConcept? details = operationOutcomeStruct.issue[0].details;
+        if details is r4:CodeableConcept {
+            string? text = details.text;
+            if text is string {
+                return text;
+            } else {
+                return error("Error in extracting details text from operation outcome");
+            }
+        } else {
+            return error("Error in extracting details from operation outcome");
+        }
+    } else {
+        return error("Error in parsing the response payload");
+    }
+}

--- a/fhirr4/ballerina/src/main/resources/fhirservice/tests/test_api_config.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/tests/test_api_config.bal
@@ -1,21 +1,16 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
-
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at
-
 // http://www.apache.org/licenses/LICENSE-2.0
-
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerinax/health.fhir.r4;
-
 
 final r4:ResourceAPIConfig apiConfig = {
     resourceType: "Patient",
@@ -271,5 +266,76 @@ final r4:ResourceAPIConfig apiConfigNoPagination = {
     ],
     serverConfig: (),
     paginationConfig: {
-        enabled: false}
+        enabled: false
+    }
+};
+
+final r4:ResourceAPIConfig operationsApiConfig = {
+    resourceType: "ConceptMap",
+    authzConfig: (),
+    profiles: [
+        "http://hl7.org/fhir/StructureDefinition/ConceptMap"
+    ],
+    defaultProfile: (),
+    searchParameters: [],
+    operations: [
+        {
+            name: "closure",
+            active: false,
+            parameters: [
+                {
+                    name: "name",
+                    active: true
+                },
+                {
+                    name: "concept",
+                    active: true
+                },
+                {
+                    name: "version",
+                    active: true
+                }
+            ]
+        },
+        {
+            name: "translate",
+            active: true,
+            parameters: [
+                {
+                    name: "url",
+                    active: true,
+                    min: 1 // Mandatory param
+                },
+                {
+                    name: "conceptMap",
+                    active: true
+                },
+                {
+                    name: "system",
+                    active: true,
+                    max: "2", // Max 2 params 
+                    scopes: [r4:FHIR_INTERACTION_INSTANCE] // Only for instance level
+                },
+                {
+                    name: "version",
+                    active: false
+                },
+                {
+                    name: "dependency",
+                    active: true,
+                    parts: [
+                        {
+                            name: "element",
+                            active: true
+                        },
+                        {
+                            name: "concept",
+                            active: true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    serverConfig: ()
 };

--- a/fhirr4/ballerina/src/main/resources/fhirservice/tests/test_service.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/tests/test_service.bal
@@ -1,22 +1,18 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
-
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at
-
 // http://www.apache.org/licenses/LICENSE-2.0
-
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerinax/health.fhir.r4.international401;
-import ballerinax/health.fhir.r4;
 import ballerina/http;
+import ballerinax/health.fhir.r4;
 
 type ServiceTestError distinct error;
 
@@ -257,5 +253,83 @@ Service fhirServiceNoPagination = service object {
             }
         ];
         return r4:createFhirBundle(r4:BUNDLE_TYPE_SEARCHSET, patients);
+    }
+};
+
+// This service is used to test FHIR extended operations
+Service fhirOperationsService = service object {
+    resource function get fhir/r4/ConceptMap/\$translate(r4:FHIRContext fhirCtx)
+            returns international401:Parameters|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
+    }
+
+    resource function post fhir/r4/ConceptMap/\$translate(r4:FHIRContext fhirCtx,
+            international401:Parameters parameters) returns international401:Parameters|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
+    }
+
+    resource function get fhir/r4/ConceptMap/[string id]/\$translate(r4:FHIRContext fhirCtx,
+            international401:Parameters parameters) returns international401:Parameters|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
+    }
+
+    // Base operation resource function
+    resource function get fhir/r4/ConceptMap/\$meta(r4:FHIRContext fhirCtx)
+            returns r4:Meta|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
+    }
+
+    resource function get fhir/r4/\$closure(r4:FHIRContext fhirCtx)
+            returns international401:ConceptMap|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {status: "active"};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
+    }
+
+    // Invalid operation resource function for testing.
+    // 'ConceptMap' resource does not have a '$find-matches' operation.
+    resource function get fhir/r4/ConceptMap/\$find\-matches(r4:FHIRContext fhirCtx)
+            returns international401:Parameters|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
+    }
+
+    // Invalid operation resource function for testing. 
+    // '$translate' operation does not support system scope.
+    resource function get fhir/r4/\$translate(r4:FHIRContext fhirCtx)
+            returns international401:Parameters|ServiceTestError {
+        r4:FHIRInteraction interaction = fhirCtx.getInteraction();
+        if interaction is r4:FHIROperationInteraction {
+            return {};
+        } else {
+            return error("Incorrect interaction engaged!");
+        }
     }
 };


### PR DESCRIPTION
## Purpose
> This PR adds the FHIR extended operation execution and preprocessing support to the FHIR service.

Related issue: https://github.com/wso2-enterprise/open-healthcare/issues/1562