### PR TITLE
Make required 'operations' field in 'IGInfoRecord' in r4 optional

### DIFF
--- a/r4/fhir_implementation_guide.bal
+++ b/r4/fhir_implementation_guide.bal
@@ -42,7 +42,7 @@ public isolated class FHIRImplementationGuide {
     # Get IG FHIR operation definitions.
     #
     # + return - A map of FHIR operation definitions
-    public isolated function getOperations() returns map<FHIROperationDefinition[]> {
+    public isolated function getOperations() returns map<FHIROperationDefinition[]>? {
         return self.igRecord.operations;
     }
 }
@@ -61,5 +61,5 @@ public type IGInfoRecord record {|
     Terminology terminology;
     readonly & map<Profile> profiles;
     readonly & map<FHIRSearchParameterDefinition[]>[] searchParameters;
-    readonly & map<FHIROperationDefinition[]> operations;
+    readonly & map<FHIROperationDefinition[]> operations?;
 |};

--- a/r4/fhir_registry.bal
+++ b/r4/fhir_registry.bal
@@ -137,20 +137,23 @@ public isolated class FHIRRegistry {
 
         lock {
             // Add operations
-            foreach FHIROperationDefinition[] operationsMap in ig.getOperations() {
-                foreach FHIROperationDefinition operation in operationsMap {
-                    string[]? resources = operation.'resource;
-                    if resources is string[] {
-                        foreach string resourceType in resources {
-                            if self.operationsMap.hasKey(resourceType) {
-                                OperationCollection collection = self.operationsMap.get(resourceType);
-                                if !collection.hasKey(operation.name) {
-                                    collection[operation.name] = operation;
+            map<FHIROperationDefinition[]>? igOperationsDefinitionsMap = ig.getOperations();
+            if igOperationsDefinitionsMap != () {
+                foreach FHIROperationDefinition[] operationDefinitions in igOperationsDefinitionsMap {
+                    foreach FHIROperationDefinition operationDefinition in operationDefinitions {
+                        string[]? resources = operationDefinition.'resource;
+                        if resources is string[] {
+                            foreach string resourceType in resources {
+                                if self.operationsMap.hasKey(resourceType) {
+                                    OperationCollection collection = self.operationsMap.get(resourceType);
+                                    if !collection.hasKey(operationDefinition.name) {
+                                        collection[operationDefinition.name] = operationDefinition;
+                                    }
+                                } else {
+                                    OperationCollection collection = {};
+                                    collection[operationDefinition.name] = operationDefinition;
+                                    self.operationsMap[resourceType] = collection;
                                 }
-                            } else {
-                                OperationCollection collection = {};
-                                collection[operation.name] = operation;
-                                self.operationsMap[resourceType] = collection;
                             }
                         }
                     }


### PR DESCRIPTION
## Purpose
> This PR includes a hotfix that makes the previously required `operations` field in `IGInfoRecord` (introduced in r4 v6.0.0) optional. Since this field can be made optional, it should be. Making this an optional field reduces dependent package breakages that might occur because of this change.

Related issues: https://github.com/wso2-enterprise/open-healthcare/issues/1593, https://github.com/wso2-enterprise/open-healthcare/issues/1592