### PR TITLE
Use setup-ballerina for Ballerina versioning

### DIFF
--- a/.github/workflows/build-executor.yml
+++ b/.github/workflows/build-executor.yml
@@ -9,6 +9,8 @@ on:
       bal_central_environment:
         required: true
         type: string
+env:
+  BALLERINA_VERSION: 2201.9.0
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -17,74 +19,66 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: $BALLERINA_VERSION
+
       - name: Run ballerina build for staging
         if: inputs.bal_central_environment == 'STAGE'
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm   
+        env:   
           BALLERINA_STAGE_CENTRAL: true
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal pack
+          popd
 
       - name: Run ballerina build for dev
         if: inputs.bal_central_environment == 'DEV'
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm 
+        env: 
           BALLERINA_DEV_CENTRAL: true
-          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }} 
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal pack
+          popd
 
       - name: Run ballerina build for prod
         if: inputs.bal_central_environment == 'PROD'
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm 
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal pack
+          popd
 
       - name: Push to Staging
         if: inputs.bal_central_environment == 'STAGE'
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-             push
         env:
-            WORKING_DIR:  ${{ inputs.working_dir }}
-            JAVA_HOME: /usr/lib/jvm/default-jvm
             BALLERINA_STAGE_CENTRAL: true
             BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal push
+          popd
 
       - name: Push to Dev
         if: inputs.bal_central_environment == 'DEV'
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-            push
         env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm
           BALLERINA_DEV_CENTRAL: true
-          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}     
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal push
+          popd    
 
       - name: Push to Prod
         if: inputs.bal_central_environment == 'PROD'
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-            push
         env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal push
+          popd
 
       - name: Publish Release
         if: inputs.bal_central_environment == 'PROD'
@@ -123,13 +117,10 @@ jobs:
 
       - name: Ballerina Build after incrementing version
         if: ${{ inputs.bal_central_environment == 'PROD' }}
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args:
-            pack
-        env:
-          WORKING_DIR: ${{ inputs.working_dir }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm
+        run: |
+          pushd "${{ inputs.working_dir }}"
+          bal pack
+          popd
 
       - name: Commit changes and make a PR
         if: ${{ inputs.bal_central_environment == 'PROD' }}

--- a/.github/workflows/cd-fhirr4.yml
+++ b/.github/workflows/cd-fhirr4.yml
@@ -12,6 +12,9 @@ on:
         - PROD
         required: true
 
+env:
+  BALLERINA_VERSION: 2201.9.0
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
       - name: Setup latest Ballerina version
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: 2201.8.1
+          version: $BALLERINA_VERSION
       
       - name: Print ballerina version
         run: bal version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   R4_PATTERN: '*/*'
   UTILS_PATTERN: 'utils/*/*'
   GITHUB_WORKFLOWS_DIR: '.github'
+  BALLERINA_VERSION: 2201.9.0
 
 jobs:
   setup:
@@ -88,14 +89,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: $BALLERINA_VERSION
+
       - name: Ballerina Build
         if: ${{ matrix.path != 'fhirr4' }}
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args: pack
-        env:
-          WORKING_DIR: ./${{ matrix.path }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm
+        run: |
+          pushd "${{ matrix.path }}"
+          bal pack
+          popd
 
       - name: Setup Maven
         if: ${{ matrix.path == 'fhirr4' }}
@@ -103,12 +107,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Setup latest Ballerina version
-        uses: ballerina-platform/setup-ballerina@v1.1.0
-        if: ${{ matrix.path == 'fhirr4' }}
-        with:
-          version: 2201.8.1
 
       - name: Create settings.xml
         if: ${{ matrix.path == 'fhirr4' }}
@@ -141,14 +139,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: $BALLERINA_VERSION
+
       - name: Ballerina Test
         if: ${{ matrix.path != 'fhirr4' }}
-        uses: ballerina-platform/ballerina-action@2201.9.0
-        with:
-          args: test --code-coverage
-        env:
-          WORKING_DIR: ./${{ matrix.path }}
-          JAVA_HOME: /usr/lib/jvm/default-jvm
+        run: |
+          pushd "${{ matrix.path }}"
+          bal test --code-coverage
+          popd
 
       - name: Setup Maven
         if: ${{ matrix.path == 'fhirr4' }}
@@ -156,12 +157,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Setup latest Ballerina version
-        uses: ballerina-platform/setup-ballerina@v1.1.0
-        if: ${{ matrix.path == 'fhirr4' }}
-        with:
-          version: 2201.8.1
 
       - name: Create settings.xml
         if: ${{ matrix.path == 'fhirr4' }}

--- a/.github/workflows/fhirr4-graalvm-check.yml
+++ b/.github/workflows/fhirr4-graalvm-check.yml
@@ -3,6 +3,9 @@ name: FHIRR4 GraalVM Check
 on:
   workflow_dispatch:
 
+env:
+  BALLERINA_VERSION: 2201.9.0
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,7 +31,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: 2201.8.1
+          version: $BALLERINA_VERSION
 
       - name: Setup Java and Maven
         uses: actions/setup-java@v2


### PR DESCRIPTION
This PR updates the workflows to leverage the `setup-ballerina` action for managing Ballerina versions.
This change removes the previous usage of the `ballerina-action`.
