### PR TITLE
[Release fhirr4 1.3.0] Prepare for release

### DIFF
--- a/fhirr4/ballerina/pom.xml
+++ b/fhirr4/ballerina/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>1.2.5</version>
+        <version>1.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/compiler-plugin/pom.xml
+++ b/fhirr4/compiler-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>1.2.5</version>
+        <version>1.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/native/pom.xml
+++ b/fhirr4/native/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>1.2.5</version>
+        <version>1.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/pom.xml
+++ b/fhirr4/pom.xml
@@ -25,7 +25,7 @@
     <groupId>io.ballerinax</groupId>
     <artifactId>fhirr4</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.5</version>
+    <version>1.3.0</version>
     <modules>
         <module>compiler-plugin</module>
         <module>native</module>


### PR DESCRIPTION
## Purpose
> This minor release fixes the dependency conflicts of fhirr4.
