### PR TITLE
Migrate FHIR packages to Ballerina Update 10

### DIFF
--- a/.github/workflows/build-executor.yml
+++ b/.github/workflows/build-executor.yml
@@ -9,8 +9,16 @@ on:
       bal_central_environment:
         required: true
         type: string
+      ballerina_version:
+        description: Ballerina Version
+        type: choice
+        options:
+        - 2201.9.0
+        - 2201.8.5
+        - 2201.10.2
+        required: true
 env:
-  BALLERINA_VERSION: 2201.8.6
+  # BALLERINA_VERSION: 2201.8.6
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,7 +30,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: $BALLERINA_VERSION
+          version: ${{ inputs.ballerina_version }}
 
       - name: Run ballerina build for staging
         if: inputs.bal_central_environment == 'STAGE'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   UTILS_PATTERN: 'utils/*/*'
   AU_PATTERN: 'au/*/*'
   GITHUB_WORKFLOWS_DIR: '.github'
-  BALLERINA_VERSION: 2201.8.6
+  BALLERINA_VERSION: 2201.10.2
 
 jobs:
   setup:

--- a/r4/Ballerina.toml
+++ b/r4/Ballerina.toml
@@ -1,8 +1,8 @@
 [package]
 org = "ballerinax"
 name = "health.fhir.r4"
-version = "5.1.2"
-distribution = "2201.8.6"
+version = "5.2.0"
+distribution = "2201.10.2"
 authors = ["Ballerina"]
 keywords = ["Healthcare", "FHIR", "R4"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-health.fhir.r4"

--- a/r4/Dependencies.toml
+++ b/r4/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.6"
+distribution-version = "2201.10.2"
 
 [[package]]
 org = "ballerina"
@@ -286,6 +286,7 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.error"}
 ]
 modules = [
@@ -351,7 +352,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4"
-version = "5.1.2"
+version = "5.2.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},


### PR DESCRIPTION
## Purpose
> related issue: https://github.com/wso2-enterprise/open-healthcare/issues/1644
The following packages will be migrated with this;

- health.fhir.r4
- health.fhir.international401
- health.fhir.parser
- health.fhir.fhirr4

