### PR TITLE
Refactor `health.fhir.r4.validator` Package to Add Terminology Validation

### DIFF
--- a/validator/Ballerina.toml
+++ b/validator/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "health.fhir.r4.validator"
-version = "5.0.1"
+version = "5.0.2"
 distribution = "2201.12.2"
 authors = ["Ballerina"]
 keywords = ["Healthcare", "FHIR", "R4", "Validator"]

--- a/validator/Dependencies.toml
+++ b/validator/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.2"
+distribution-version = "2201.12.0-20250228-201300-8d411a0f"
 
 [[package]]
 org = "ballerina"
@@ -110,6 +110,9 @@ version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
 ]
 
 [[package]]
@@ -394,6 +397,7 @@ version = "5.0.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "test"},

--- a/validator/Dependencies.toml
+++ b/validator/Dependencies.toml
@@ -111,9 +111,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
@@ -392,18 +389,32 @@ modules = [
 
 [[package]]
 org = "ballerinax"
+name = "health.fhir.r4.uscore700"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "constraint"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerinax", name = "health.fhir.r4"}
+]
+modules = [
+	{org = "ballerinax", packageName = "health.fhir.r4.uscore700", moduleName = "health.fhir.r4.uscore700"}
+]
+
+[[package]]
+org = "ballerinax"
 name = "health.fhir.r4.validator"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerinax", name = "health.fhir.r4"},
 	{org = "ballerinax", name = "health.fhir.r4.international401"},
-	{org = "ballerinax", name = "health.fhir.r4.parser"}
+	{org = "ballerinax", name = "health.fhir.r4.parser"},
+	{org = "ballerinax", name = "health.fhir.r4.uscore700"}
 ]
 modules = [
 	{org = "ballerinax", packageName = "health.fhir.r4.validator", moduleName = "health.fhir.r4.validator"}

--- a/validator/tests/test.bal
+++ b/validator/tests/test.bal
@@ -21,7 +21,7 @@ import ballerina/test;
 import ballerina/http;
 
 @test:Config{}
-function testValidate() {
+function testValidate1() {
     json body = {
       "resourceType": "Patient",
       "id": "591841",
@@ -49,6 +49,73 @@ function testValidate() {
     if validationResult is r4:FHIRValidationError {
         test:assertFail(msg = "Validation failed");
     }
+}
+
+@test:Config{}
+function testValidate2() {
+  json body = {
+    "resourceType": "AllergyIntolerance",
+    "id": "example",
+    "text": {
+      "status": "generated",
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
+    },
+    "clinicalStatus": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          "code": "active"
+        }
+      ]
+    },
+    "verificationStatus": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+          "code": "confirmed"
+        }
+      ]
+    },
+    "category": ["medication"],
+    "criticality": "high",
+    "code": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/731000124108",
+          "code": "763875007",
+          "display": "Product containing sulfonamide (product)"
+        }
+      ],
+      "text": "sulfonamide antibacterial"
+    },
+    "patient": {
+      "reference": "Patient/example",
+      "display": "Amy V. Shaw"
+    },
+    "reaction": [
+      {
+        "manifestation": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/731000124108",
+                "code": "271807003",
+                "display": "skin rash"
+              }
+            ],
+            "text": "skin rash"
+          }
+        ],
+        "severity": "mild"
+      }
+    ]
+  };
+  r4:FHIRValidationError? validationResult = validate(body);
+  if validationResult is r4:FHIRValidationError {
+    test:assertFail(msg = "Validation failed");
+  }
 }
 
 @test:Config{}

--- a/validator/tests/test.bal
+++ b/validator/tests/test.bal
@@ -15,35 +15,42 @@
 // under the License.
 
 import ballerina/constraint;
+import ballerina/http;
+import ballerina/test;
 import ballerinax/health.fhir.r4;
 import ballerinax/health.fhir.r4.international401;
-import ballerina/test;
-import ballerina/http;
+import ballerinax/health.fhir.r4.uscore700;
 
-@test:Config{}
+@test:Config {}
 function testValidate1() {
     json body = {
-      "resourceType": "Patient",
-      "id": "591841",
-      "meta": {
-        "versionId": "1",
-        "lastUpdated": "2020-01-22T05:30:13.137+00:00",
-        "source": "#KO38Q3spgrJoP5fa"
-      },
-      "identifier": [ {
-        "type": {
-          "coding": [ {
-            "system": "http://hl7.org/fhir/v2/0203",
-            "code": "MR"
-          } ]
+        "resourceType": "Patient",
+        "id": "591841",
+        "meta": {
+            "versionId": "1",
+            "lastUpdated": "2020-01-22T05:30:13.137+00:00",
+            "source": "#KO38Q3spgrJoP5fa"
         },
-        "value": "18e5fd39-7444-4b30-91d4-57226deb2c78"
-      } ],
-      "name": [ {
-        "family": "Cushing",
-        "given": [ "Caleb" ]
-      } ],
-      "birthDate": "2000-01-01"
+        "identifier": [
+            {
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v2/0203",
+                            "code": "MR"
+                        }
+                    ]
+                },
+                "value": "18e5fd39-7444-4b30-91d4-57226deb2c78"
+            }
+        ],
+        "name": [
+            {
+                "family": "Cushing",
+                "given": ["Caleb"]
+            }
+        ],
+        "birthDate": "2000-01-01"
     };
     r4:FHIRValidationError? validationResult = validate(body);
     if validationResult is r4:FHIRValidationError {
@@ -51,97 +58,172 @@ function testValidate1() {
     }
 }
 
-@test:Config{}
+@test:Config {}
 function testValidate2() {
-  json body = {
-    "resourceType": "AllergyIntolerance",
-    "id": "example",
-    "text": {
-      "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
-    },
-    "clinicalStatus": {
-      "coding": [
-        {
-          "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
-          "code": "active"
-        }
-      ]
-    },
-    "verificationStatus": {
-      "coding": [
-        {
-          "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-          "code": "confirmed"
-        }
-      ]
-    },
-    "category": ["medication"],
-    "criticality": "high",
-    "code": {
-      "coding": [
-        {
-          "system": "http://snomed.info/sct",
-          "version": "http://snomed.info/sct/731000124108",
-          "code": "763875007",
-          "display": "Product containing sulfonamide (product)"
-        }
-      ],
-      "text": "sulfonamide antibacterial"
-    },
-    "patient": {
-      "reference": "Patient/example",
-      "display": "Amy V. Shaw"
-    },
-    "reaction": [
-      {
-        "manifestation": [
-          {
+    json body = {
+        "resourceType": "AllergyIntolerance",
+        "id": "example",
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
             "coding": [
-              {
-                "system": "http://snomed.info/sct",
-                "version": "http://snomed.info/sct/731000124108",
-                "code": "271807003",
-                "display": "skin rash"
-              }
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                    "code": "active"
+                }
+            ]
+        },
+        "verificationStatus": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                    "code": "confirmed"
+                }
+            ]
+        },
+        "category": ["medication"],
+        "criticality": "high",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "version": "http://snomed.info/sct/731000124108",
+                    "code": "763875007",
+                    "display": "Product containing sulfonamide (product)"
+                }
             ],
-            "text": "skin rash"
-          }
-        ],
-        "severity": "mild"
-      }
-    ]
-  };
-  r4:FHIRValidationError? validationResult = validate(body);
-  if validationResult is r4:FHIRValidationError {
-    test:assertFail(msg = "Validation failed");
-  }
+            "text": "sulfonamide antibacterial"
+        },
+        "patient": {
+            "reference": "Patient/example",
+            "display": "Amy V. Shaw"
+        },
+        "reaction": [
+            {
+                "manifestation": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "version": "http://snomed.info/sct/731000124108",
+                                "code": "271807003",
+                                "display": "skin rash"
+                            }
+                        ],
+                        "text": "skin rash"
+                    }
+                ],
+                "severity": "mild"
+            }
+        ]
+    };
+    r4:FHIRValidationError? validationResult = validate(body);
+    if validationResult is r4:FHIRValidationError {
+        test:assertFail(msg = "Validation failed");
+    }
 }
 
-@test:Config{}
+@test:Config {}
+function testValidateTerminologyError() {
+    json body = {
+        "resourceType": "AllergyIntolerance",
+        "id": "example",
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                    "code": "active"
+                }
+            ]
+        },
+        "verificationStatus": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                    "code": "invalid_term" // invalid code
+                }
+            ]
+        },
+        "category": ["medication"],
+        "criticality": "high",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "version": "http://snomed.info/sct/731000124108",
+                    "code": "763875007",
+                    "display": "Product containing sulfonamide (product)"
+                }
+            ],
+            "text": "sulfonamide antibacterial"
+        },
+        "patient": {
+            "reference": "Patient/example",
+            "display": "Amy V. Shaw"
+        },
+        "reaction": [
+            {
+                "manifestation": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "version": "http://snomed.info/sct/731000124108",
+                                "code": "271807003",
+                                "display": "skin rash"
+                            }
+                        ],
+                        "text": "skin rash"
+                    }
+                ],
+                "severity": "mild"
+            }
+        ]
+    };
+    r4:FHIRValidationError? validationResult = validate(body);
+    if validationResult is r4:FHIRValidationError {
+        test:assertEquals(validationResult.detail().httpStatusCode, http:STATUS_BAD_REQUEST);
+    } else {
+        test:assertFail(msg = "Expected error is not thrown");
+    }
+}
+
+@test:Config {}
 function testValidateConstrainError() {
     json body = {
-      "resourceType": "Patient",
-      "id": "591841",
-      "meta": {
-        "versionId": "1",
-        "lastUpdated": "2020-01-22T05:30:13.137+00:00",
-        "source": "#KO38Q3spgrJoP5fa"
-      },
-      "identifier": [ {
-        "type": {
-          "coding": [ {
-            "system": "http://hl7.org/fhir/v2/0203",
-            "code": "MR"
-          } ]
+        "resourceType": "Patient",
+        "id": "591841",
+        "meta": {
+            "versionId": "1",
+            "lastUpdated": "2020-01-22T05:30:13.137+00:00",
+            "source": "#KO38Q3spgrJoP5fa"
         },
-        "value": "18e5fd39-7444-4b30-91d4-57226deb2c78"
-      } ],
-      "name": [ {
-        "family": "Cushing",
-        "given": [ "Caleb" ]
-      } ],
-      "birthDate": "aabbcc"
+        "identifier": [
+            {
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v2/0203",
+                            "code": "MR"
+                        }
+                    ]
+                },
+                "value": "18e5fd39-7444-4b30-91d4-57226deb2c78"
+            }
+        ],
+        "name": [
+            {
+                "family": "Cushing",
+                "given": ["Caleb"]
+            }
+        ],
+        "birthDate": "aabbcc"
     };
     r4:FHIRValidationError? validationResult = validate(body);
     if validationResult is r4:FHIRValidationError {
@@ -152,29 +234,35 @@ function testValidateConstrainError() {
     }
 }
 
-@test:Config{}
+@test:Config {}
 function testValidateParseError() {
     json body = {
-      "id": "591841",
-      "meta": {
-        "versionId": "1",
-        "lastUpdated": "2020-01-22T05:30:13.137+00:00",
-        "source": "#KO38Q3spgrJoP5fa"
-      },
-      "identifier": [ {
-        "type": {
-          "coding": [ {
-            "system": "http://hl7.org/fhir/v2/0203",
-            "code": "MR"
-          } ]
+        "id": "591841",
+        "meta": {
+            "versionId": "1",
+            "lastUpdated": "2020-01-22T05:30:13.137+00:00",
+            "source": "#KO38Q3spgrJoP5fa"
         },
-        "value": "18e5fd39-7444-4b30-91d4-57226deb2c78"
-      } ],
-      "name": [ {
-        "family": "Cushing",
-        "given": [ "Caleb" ]
-      } ],
-      "birthDate": "2000-01-01"
+        "identifier": [
+            {
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v2/0203",
+                            "code": "MR"
+                        }
+                    ]
+                },
+                "value": "18e5fd39-7444-4b30-91d4-57226deb2c78"
+            }
+        ],
+        "name": [
+            {
+                "family": "Cushing",
+                "given": ["Caleb"]
+            }
+        ],
+        "birthDate": "2000-01-01"
     };
     r4:FHIRValidationError? validationResult = validate(body);
     if validationResult is r4:FHIRValidationError {
@@ -185,8 +273,8 @@ function testValidateParseError() {
     }
 }
 
-@test:Config{}
-function testXml(){
+@test:Config {}
+function testXml() {
     xml x = xml `<test>test</test>`;
     r4:FHIRValidationError? validationResult = validate(x);
     test:assertTrue(validationResult is r4:FHIRValidationError);
@@ -197,24 +285,24 @@ function testXml(){
     }
 }
 
-@test:Config{}
+@test:Config {}
 function testRecord() {
     international401:Patient p = {
         id: "591841",
         birthDate: "2000-01-01"
-    };    
+    };
     r4:FHIRValidationError? validationResult = validate(p);
     if validationResult is r4:FHIRValidationError {
         test:assertFail(msg = "Validation failed");
     }
 }
 
-@test:Config{}
+@test:Config {}
 function testRecordConstraintError() {
     international401:Patient p = {
         id: "591841",
         birthDate: "abcdef"
-    };    
+    };
     r4:FHIRValidationError? validationResult = validate(p);
     if validationResult is r4:FHIRValidationError {
         test:assertTrue(validationResult.cause() is constraint:Error);
@@ -224,8 +312,8 @@ function testRecordConstraintError() {
     }
 }
 
-@test:Config{}
-function testInvalidPayload(){
+@test:Config {}
+function testInvalidPayload() {
     record {string name; int age;} random = {name: "vijay", age: 30};
     r4:FHIRValidationError? validationResult = validate(random);
     test:assertTrue(validationResult is r4:FHIRValidationError);
@@ -236,8 +324,8 @@ function testInvalidPayload(){
     }
 }
 
-@test:Config{}
-function testTargetType() {
+@test:Config {}
+function testTargetType1() {
     json patientPayload = {
         "resourceType": "Patient",
         "id": "example-patient",
@@ -283,7 +371,237 @@ function testTargetType() {
     }
 }
 
-@test:Config{}
+@test:Config {}
+function testTargetType2() {
+    json testPayload = {
+        "resourceType": "AllergyIntolerance",
+        "id": "example",
+        "meta": {
+            "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"]
+        },
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
+        },
+        "clinicalStatus": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                    "code": "active"
+                }
+            ]
+        },
+        "verificationStatus": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                    "code": "confirmed"
+                }
+            ]
+        },
+        "category": ["medication"],
+        "criticality": "high",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "version": "http://snomed.info/sct/731000124108",
+                    "code": "763875007",
+                    "display": "Product containing sulfonamide (product)"
+                }
+            ],
+            "text": "sulfonamide antibacterial"
+        },
+        "patient": {
+            "reference": "Patient/example",
+            "display": "Amy V. Shaw"
+        },
+        "reaction": [
+            {
+                "manifestation": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "version": "http://snomed.info/sct/731000124108",
+                                "code": "271807003",
+                                "display": "skin rash"
+                            }
+                        ],
+                        "text": "skin rash"
+                    }
+                ],
+                "severity": "mild"
+            }
+        ]
+    };
+    r4:FHIRValidationError? validationResult = validate(testPayload, uscore700:USCoreAllergyIntolerance);
+    if validationResult is r4:FHIRValidationError {
+        test:assertFail(msg = "Validation failed");
+    }
+}
+
+@test:Config {}
+function testValidateTerminologySystemNotDefinedInPackage() {
+    json body = {
+        "resourceType": "Patient",
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                "extension": [
+                    {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2106-3",
+                            "display": "White"
+                        }
+                    },
+                    {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "1002-5",
+                            "display": "American Indian or Alaska Native"
+                        }
+                    },
+                    {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2028-9",
+                            "display": "Asian"
+                        }
+                    },
+                    {
+                        "url": "detailed",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "1586-7",
+                            "display": "Shoshone"
+                        }
+                    },
+                    {
+                        "url": "detailed",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2036-2",
+                            "display": "Filipino"
+                        }
+                    },
+                    {
+                        "url": "text",
+                        "valueString": "Mixed"
+                    }
+                ]
+            },
+            {
+                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+                "extension": [
+                    {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2135-2",
+                            "display": "Hispanic or Latino"
+                        }
+                    },
+                    {
+                        "url": "detailed",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2184-0",
+                            "display": "Dominican"
+                        }
+                    },
+                    {
+                        "url": "detailed",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2148-5",
+                            "display": "Mexican"
+                        }
+                    },
+                    {
+                        "url": "text",
+                        "valueString": "Hispanic or Latino"
+                    }
+                ]
+            },
+            {
+                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                "valueCode": "F"
+            }
+        ],
+        "gender": "female",
+        "telecom": [
+            {
+                "system": "phone",
+                "use": "home",
+                "value": "555-555-5555"
+            },
+            {
+                "system": "email",
+                "value": "amy.shaw@example.com"
+            }
+        ],
+        "id": "101",
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>\n\t\t\t\t<b>Generated Narrative with Details</b>\n\t\t\t</p>\n\t\t\t<p>\n\t\t\t\t<b>id</b>: example</p>\n\t\t\t<p>\n\t\t\t\t<b>identifier</b>: Medical Record Number = 1032702 (USUAL)</p>\n\t\t\t<p>\n\t\t\t\t<b>active</b>: true</p>\n\t\t\t<p>\n\t\t\t\t<b>name</b>: Amy V. Shaw </p>\n\t\t\t<p>\n\t\t\t\t<b>telecom</b>: ph: 555-555-5555(HOME), amy.shaw@example.com</p>\n\t\t\t<p>\n\t\t\t\t<b>gender</b>: </p>\n\t\t\t<p>\n\t\t\t\t<b>birthsex</b>: Female</p>\n\t\t\t<p>\n\t\t\t\t<b>birthDate</b>: Feb 20, 2007</p>\n\t\t\t<p>\n\t\t\t\t<b>address</b>: 49 Meadow St Mounds OK 74047 US </p>\n\t\t\t<p>\n\t\t\t\t<b>race</b>: White, American Indian or Alaska Native, Asian, Shoshone, Filipino</p>\n\t\t\t<p>\n\t\t\t\t<b>ethnicity</b>: Hispanic or Latino, Dominican, Mexican</p>\n\t\t</div>"
+        },
+        "identifier": [
+            {
+                "system": "http://hospital.smarthealthit.org",
+                "use": "usual",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                            "code": "MR",
+                            "display": "Medical Record Number"
+                        }
+                    ],
+                    "text": "Medical Record Number"
+                },
+                "value": "1032702"
+            }
+        ],
+        "address": [
+            {
+                "country": "US",
+                "city": "Mounds",
+                "line": [
+                    "49 Meadow St"
+                ],
+                "postalCode": "74047",
+                "state": "OK"
+            }
+        ],
+        "active": true,
+        "birthDate": "2007-02-20",
+        "meta": {
+            "profile": [
+                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            ]
+        },
+        "name": [
+            {
+                "given": [
+                    "Jack",
+                    "V."
+                ],
+                "family": "Shaw"
+            }
+        ]
+    };
+    r4:FHIRValidationError? validationResult = validate(body, uscore700:USCorePatientProfile);
+    if validationResult is r4:FHIRValidationError {
+        test:assertFail(msg = "Validation failed");
+    }
+}
+
+@test:Config {}
 function testDatetimeErrorMessageParsing() {
     string errorMessage = string `Validation failed for '$.identifier[0].period.start:pattern' constraint(s).`;
     string[] parsedError = parseConstraintErrors(errorMessage);
@@ -291,7 +609,7 @@ function testDatetimeErrorMessageParsing() {
     test:assertTrue(parsedError == ["Invalid pattern (constraint) for field 'identifier[0].period.start'"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testResourceTypeParsing() {
     string errorMessage = string `Failed to find FHIR profile for the resource type : Psatient`;
     string[] parsedError = processFHIRParserErrors(errorMessage);
@@ -299,7 +617,7 @@ function testResourceTypeParsing() {
     test:assertTrue(parsedError == ["Resource type is invalid"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testMissingFieldParsing() {
     string errorMessage = string `Failed to parse request body as JSON resource due to Invalid JSON content detected, missing required element: "resourceType"`;
     string[] parsedError = processFHIRParserErrors(errorMessage);
@@ -307,7 +625,7 @@ function testMissingFieldParsing() {
     test:assertTrue(parsedError == ["Missing required Element: 'resourceType'"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testMissingElementParsing() {
     string errorMessage = string `Failed to parse request body as JSON resource due to 'map<json>' value cannot be converted to 'health.fhir.r4.international401:Patient':
                 missing required field 'text.status' of type 'ballerinax/health.fhir.r4:4:StatusCode' in record 'health.fhir.r4:Narrative'`;
@@ -316,7 +634,7 @@ function testMissingElementParsing() {
     test:assertTrue(parsedError == ["Missing required field 'text.status'"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testInvalidFieldParsing() {
     string errorMessage = string `Failed to parse request body as JSON resource due to 'map<json>' value cannot be converted to 'health.fhir.r4.international401:Patient':
                 value of field 'isd' adding to the record 'health.fhir.r4.international401:Patient' should be of type 'health.fhir.r4:Element', found '"example"'`;
@@ -325,7 +643,7 @@ function testInvalidFieldParsing() {
     test:assertTrue(parsedError == ["Invalid field 'isd'. Type of field should be 'health.fhir.r4:Element'"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testInvalidFieldValueParsing() {
     string errorMessage = string `Failed to parse request body as JSON resource due to 'map<json>' value cannot be converted to 'health.fhir.r4.international401:Patient':
                 field 'telecom[1].system' in record 'health.fhir.r4:ContactPoint' should be of type 'ballerinax/health.fhir.r4:4:ContactPointSystem', found '1'`;
@@ -334,7 +652,7 @@ function testInvalidFieldValueParsing() {
     test:assertTrue(parsedError == ["Invalid value of field 'telecom[1].system'. Type of value should be 'ballerinax/health.fhir.r4:4:ContactPointSystem'"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testInvalidArrayElements() {
     string errorMessage = string `Failed to parse request body as JSON resource due to 'map<json>' value cannot be converted to 'health.fhir.r4.international401:Patient':
                 array element 'name[0].given[0]' should be of type 'string', found '1'`;
@@ -343,7 +661,7 @@ function testInvalidArrayElements() {
     test:assertTrue(parsedError == ["Invalid array element 'name[0].given[0]'. Type of element should be 'string'"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testMultityypeScenarioFieldParsing() {
     string errorMessage = string `Failed to parse request body as JSON resource due to 'map<json>' value cannot be converted to 'health.fhir.r4.international401:Patient':
                 {
@@ -372,7 +690,7 @@ function testMultityypeScenarioFieldParsing() {
     test:assertTrue(parsedError == ["The field 'valuaeString' should be of type value[x] or url[x] where x is a valid fhir data type"]);
 }
 
-@test:Config{}
+@test:Config {}
 function testMultityypeScenarioValueParsing() {
     string errorMessage = string `Failed to parse request body as JSON resource due to 'map<json>' value cannot be converted to 'health.fhir.r4.international401:Patient': 
                 {

--- a/validator/utils.bal
+++ b/validator/utils.bal
@@ -1,13 +1,16 @@
 import ballerina/http;
-import ballerina/io;
 
-public type Term record {
+const string TERMINOLOFY_SERVICE_API = "http://localhost:9090/fhir/r4";
+const string CODESYSTEM_LOOKUP = "/Codesystem/%24lookup";
+const string VALUESET_VALIDATE_CODE = "/Valueset/%24validate-code";
+
+type Term record {
     string code;
     string system;
     string version?;
 };
 
-public isolated function extractCodesAndSystems(anydata data) returns Term[] {
+isolated function extractCodesAndSystems(anydata data) returns Term[] {
     Term[] result = [];
 
     if data is map<anydata> {
@@ -55,7 +58,7 @@ public isolated function extractCodesAndSystems(anydata data) returns Term[] {
     return result;
 }
 
-public isolated function extractFromR4Coding(anydata data) returns Term[] {
+isolated function extractFromR4Coding(anydata data) returns Term[] {
     Term[] result = [];
 
     if data is map<anydata> {
@@ -77,48 +80,36 @@ public isolated function extractFromR4Coding(anydata data) returns Term[] {
     return result;
 }
 
-public isolated function checkTerminologyValidity(Term[] terms) returns string[]|error? {
+isolated function checkTerminologyValidity(Term[] terms) returns string[]|error? {
     string[] errors = [];
-    int successCount = 0;
-    int failureCount = 0;
-    int skipCount = 0;
 
-    http:Client termClient = check new ("http://localhost:9090/fhir/r4");
-    string codeSystemLookupEndpoint = "/Codesystem/%24lookup";
-    string valueSetValidateEndpoint = "/Valueset/%24validate-code";
+    http:Client termClient = check new (TERMINOLOFY_SERVICE_API);
 
     foreach Term term in terms {
         string queryParams = string `?system=${term.system}&code=${term.code}${(term.version is string ? "&version=" + <string>term.version : "")}`;
 
         // Send GET request to ValueSet validate-code API
-        http:Response|http:Error valuesetResponse = termClient->get(valueSetValidateEndpoint + queryParams);
+        http:Response|http:Error valuesetResponse = termClient->get(VALUESET_VALIDATE_CODE + queryParams);
 
         if valuesetResponse is http:Response {
-            if valuesetResponse.statusCode == 200 {
-                successCount += 1;
-                // } else if valuesetResponse.statusCode == 404 {
-                //     failureCount += 1;
-                //     errors.push("Invalid code: " + term.code + " in system: " + term.system);
-            } else if valuesetResponse.statusCode == 404 { // 400
+            // response is 200 is valid code in the system
+            // response is 400 is not defined terminology
+            // response is 404 is not found terminology
+
+            if valuesetResponse.statusCode == 404 {
                 // Send GET request to CodeSystem lookup API
-                http:Response|http:Error codesystemResponse = termClient->get(codeSystemLookupEndpoint + queryParams);
+                http:Response|http:Error codesystemResponse = termClient->get(CODESYSTEM_LOOKUP + queryParams);
 
                 if codesystemResponse is http:Response {
-                    if codesystemResponse.statusCode == 200 {
-                        successCount += 1;
-                    } else if codesystemResponse.statusCode == 404 {
-                        failureCount += 1;
+                    if codesystemResponse.statusCode == 404 {
                         errors.push("Invalid code: " + term.code + " in system: " + term.system);
-                    } else if codesystemResponse.statusCode == 400 {
-                        skipCount += 1;
-                        io:println("System is not defined in terminology service: ", term.system);
                     }
+
+                    // skip not defined terminologies (statusCode == 400)
                 }
             }
         }
     }
-
-    io:println("Validation Summary: Successes: ", successCount, ", Failures: ", failureCount, ", Skips: ", skipCount);
 
     if errors.length() == 0 {
         return;
@@ -129,85 +120,6 @@ public isolated function checkTerminologyValidity(Term[] terms) returns string[]
 
 public isolated function validateTerminologies(anydata data) returns string[]|error? {
     Term[] result = extractCodesAndSystems(data);
-    // io:println("Extracted Codes: ", result.length());
 
     return checkTerminologyValidity(result);
 }
-
-// public function main() {
-//     json testData = {
-//         "resourceType": "AllergyIntolerance",
-//         "id": "example",
-//         "meta": {
-//             "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"]
-//         },
-//         "text": {
-//             "status": "generated",
-//             "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
-//         },
-//         "clinicalStatus": {
-//             "coding": [
-//                 {
-//                     "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
-//                     "code": "active"
-//                 }
-//             ]
-//         },
-//         "verificationStatus": {
-//             "coding": [
-//                 {
-//                     "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-//                     "code": "confirmed"
-//                 }
-//             ]
-//         },
-//         "category": ["medication"],
-//         "criticality": "high",
-//         "code": {
-//             "coding": [
-//                 {
-//                     "system": "http://snomed.info/sct",
-//                     "version": "http://snomed.info/sct/731000124108",
-//                     "code": "763875007",
-//                     "display": "Product containing sulfonamide (product)"
-//                 }
-//             ],
-//             "text": "sulfonamide antibacterial"
-//         },
-//         "patient": {
-//             "reference": "Patient/example",
-//             "display": "Amy V. Shaw"
-//         },
-//         "reaction": [
-//             {
-//                 "manifestation": [
-//                     {
-//                         "coding": [
-//                             {
-//                                 "system": "http://snomed.info/sct",
-//                                 "version": "http://snomed.info/sct/731000124108",
-//                                 "code": "271807003",
-//                                 "display": "skin rash"
-//                             }
-//                         ],
-//                         "text": "skin rash"
-//                     }
-//                 ],
-//                 "severity": "mild"
-//             }
-//         ]
-//     };
-
-//     string[]|error? validationErrors = validateTerminologies(testData);
-
-//     if validationErrors is string[] {
-//         foreach string errorString in validationErrors {
-//             io:println("Validation Error: ", errorString);
-//         }
-//     } else if validationErrors is error {
-//         io:println("Error during validation: ", validationErrors.message());
-//     } else {
-//         io:println("No validation errors found.");
-//     }
-
-// }

--- a/validator/utils.bal
+++ b/validator/utils.bal
@@ -1,0 +1,213 @@
+import ballerina/http;
+import ballerina/io;
+
+public type Term record {
+    string code;
+    string system;
+    string version?;
+};
+
+public isolated function extractCodesAndSystems(anydata data) returns Term[] {
+    Term[] result = [];
+
+    if data is map<anydata> {
+        if data.hasKey("valueCode") && data.hasKey("url") {
+            result.push({
+                code: <string>data["valueCode"],
+                system: <string>data["url"]
+            });
+
+            // check is there is not other properties in the map
+            if data.length() == 2 {
+                return result;
+            }
+        }
+
+        foreach var [key, value] in data.entries() {
+            if key == "valueCoding" && value is map<anydata> {
+                Term[] codingResult = extractFromR4Coding(value);
+                foreach Term item in codingResult {
+                    result.push(item);
+                }
+            } else if key == "coding" && value is anydata[] {
+                foreach anydata item in value {
+                    Term[] codeableResult = extractFromR4Coding(item);
+                    foreach Term codeableItem in codeableResult {
+                        result.push(codeableItem);
+                    }
+                }
+            } else if value is map<anydata> || value is anydata[] {
+                Term[] nestedResult = extractCodesAndSystems(value);
+                foreach Term item in nestedResult {
+                    result.push(item);
+                }
+            }
+        }
+    } else if data is anydata[] {
+        foreach anydata item in data {
+            Term[] arrayResult = extractCodesAndSystems(item);
+            foreach Term arrayItem in arrayResult {
+                result.push(arrayItem);
+            }
+        }
+    }
+
+    return result;
+}
+
+public isolated function extractFromR4Coding(anydata data) returns Term[] {
+    Term[] result = [];
+
+    if data is map<anydata> {
+        if data.hasKey("code") && data.hasKey("system") {
+            result.push({
+                code: <string>data["code"],
+                system: <string>data["system"],
+                version: data.hasKey("version") ? <string>data["version"] : null
+            });
+        }
+        if data.hasKey("extension") {
+            Term[] extensionResult = extractCodesAndSystems(data["extension"]);
+            foreach Term item in extensionResult {
+                result.push(item);
+            }
+        }
+    }
+
+    return result;
+}
+
+public isolated function checkTerminologyValidity(Term[] terms) returns string[]|error? {
+    string[] errors = [];
+    int successCount = 0;
+    int failureCount = 0;
+    int skipCount = 0;
+
+    http:Client termClient = check new ("http://localhost:9090/fhir/r4");
+    string codeSystemLookupEndpoint = "/Codesystem/%24lookup";
+    string valueSetValidateEndpoint = "/Valueset/%24validate-code";
+
+    foreach Term term in terms {
+        string queryParams = string `?system=${term.system}&code=${term.code}${(term.version is string ? "&version=" + <string>term.version : "")}`;
+
+        // Send GET request to ValueSet validate-code API
+        http:Response|http:Error valuesetResponse = termClient->get(valueSetValidateEndpoint + queryParams);
+
+        if valuesetResponse is http:Response {
+            if valuesetResponse.statusCode == 200 {
+                successCount += 1;
+                // } else if valuesetResponse.statusCode == 404 {
+                //     failureCount += 1;
+                //     errors.push("Invalid code: " + term.code + " in system: " + term.system);
+            } else if valuesetResponse.statusCode == 404 { // 400
+                // Send GET request to CodeSystem lookup API
+                http:Response|http:Error codesystemResponse = termClient->get(codeSystemLookupEndpoint + queryParams);
+
+                if codesystemResponse is http:Response {
+                    if codesystemResponse.statusCode == 200 {
+                        successCount += 1;
+                    } else if codesystemResponse.statusCode == 404 {
+                        failureCount += 1;
+                        errors.push("Invalid code: " + term.code + " in system: " + term.system);
+                    } else if codesystemResponse.statusCode == 400 {
+                        skipCount += 1;
+                        io:println("System is not defined in terminology service: ", term.system);
+                    }
+                }
+            }
+        }
+    }
+
+    io:println("Validation Summary: Successes: ", successCount, ", Failures: ", failureCount, ", Skips: ", skipCount);
+
+    if errors.length() == 0 {
+        return;
+    }
+
+    return errors;
+}
+
+public isolated function validateTerminologies(anydata data) returns string[]|error? {
+    Term[] result = extractCodesAndSystems(data);
+    // io:println("Extracted Codes: ", result.length());
+
+    return checkTerminologyValidity(result);
+}
+
+// public function main() {
+//     json testData = {
+//         "resourceType": "AllergyIntolerance",
+//         "id": "example",
+//         "meta": {
+//             "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"]
+//         },
+//         "text": {
+//             "status": "generated",
+//             "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: AllergyIntolerance</b><a name=\"example\"> </a><a name=\"hcexample\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource AllergyIntolerance &quot;example&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile (version 7.0.0)</a></p></div><p><b>clinicalStatus</b>: Active <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-clinical.html\">AllergyIntolerance Clinical Status Codes</a>#active)</span></p><p><b>verificationStatus</b>: Confirmed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-allergyintolerance-verification.html\">AllergyIntolerance Verification Status</a>#confirmed)</span></p><p><b>category</b>: medication</p><p><b>criticality</b>: high</p><p><b>code</b>: sulfonamide antibacterial <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#763875007 &quot;Product containing sulfonamide (product)&quot;)</span></p><p><b>patient</b>: <a href=\"Patient-example.html\">Patient/example: Amy V. Shaw</a> &quot; SHAW&quot;</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td>skin rash <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT[US]</a>#271807003)</span></td><td>mild</td></tr></table></div>"
+//         },
+//         "clinicalStatus": {
+//             "coding": [
+//                 {
+//                     "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+//                     "code": "active"
+//                 }
+//             ]
+//         },
+//         "verificationStatus": {
+//             "coding": [
+//                 {
+//                     "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+//                     "code": "confirmed"
+//                 }
+//             ]
+//         },
+//         "category": ["medication"],
+//         "criticality": "high",
+//         "code": {
+//             "coding": [
+//                 {
+//                     "system": "http://snomed.info/sct",
+//                     "version": "http://snomed.info/sct/731000124108",
+//                     "code": "763875007",
+//                     "display": "Product containing sulfonamide (product)"
+//                 }
+//             ],
+//             "text": "sulfonamide antibacterial"
+//         },
+//         "patient": {
+//             "reference": "Patient/example",
+//             "display": "Amy V. Shaw"
+//         },
+//         "reaction": [
+//             {
+//                 "manifestation": [
+//                     {
+//                         "coding": [
+//                             {
+//                                 "system": "http://snomed.info/sct",
+//                                 "version": "http://snomed.info/sct/731000124108",
+//                                 "code": "271807003",
+//                                 "display": "skin rash"
+//                             }
+//                         ],
+//                         "text": "skin rash"
+//                     }
+//                 ],
+//                 "severity": "mild"
+//             }
+//         ]
+//     };
+
+//     string[]|error? validationErrors = validateTerminologies(testData);
+
+//     if validationErrors is string[] {
+//         foreach string errorString in validationErrors {
+//             io:println("Validation Error: ", errorString);
+//         }
+//     } else if validationErrors is error {
+//         io:println("Error during validation: ", validationErrors.message());
+//     } else {
+//         io:println("No validation errors found.");
+//     }
+
+// }

--- a/validator/validator.bal
+++ b/validator/validator.bal
@@ -125,12 +125,13 @@ public isolated function validate(anydata data, typedesc<anydata>? targetFHIRMod
         // terminology validation
         string[]|error? validationErrors = validateTerminologies(validationResult);
 
-        if validationErrors is string[] {
-            foreach string errorString in validationErrors {
-                log:printDebug("Validation Error: " + errorString);
-            }
+        if validationErrors is string[] {    
+            return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed, due to terminology validation failed", r4:ERROR, r4:INVALID, "Terminology validation failed", 
+                errorType = r4:VALIDATION_ERROR, parsedErrors = validationErrors, httpStatusCode = http:STATUS_BAD_REQUEST);
         } else if validationErrors is error {
             log:printDebug("Error during validation: " + validationErrors.message());
+            return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed", r4:ERROR, r4:INVALID, "Terminology validation failed", 
+                errorType = r4:VALIDATION_ERROR, cause = validationErrors, httpStatusCode = http:STATUS_BAD_REQUEST);
         }
     }
 }

--- a/validator/validator.bal
+++ b/validator/validator.bal
@@ -121,8 +121,18 @@ public isolated function validate(anydata data, typedesc<anydata>? targetFHIRMod
         string[] errors = parseConstraintErrors(validationResult.message());
         return <r4:FHIRValidationError>createValidationError("FHIR resource validation failed", r4:ERROR, r4:INVALID, validationResult.message(),
                                                 errorType = r4:VALIDATION_ERROR, cause = validationResult, parsedErrors = errors, httpStatusCode = http:STATUS_BAD_REQUEST);
-    }
+    } else {
+        // terminology validation
+        string[]|error? validationErrors = validateTerminologies(validationResult);
 
+        if validationErrors is string[] {
+            foreach string errorString in validationErrors {
+                log:printDebug("Validation Error: " + errorString);
+            }
+        } else if validationErrors is error {
+            log:printDebug("Error during validation: " + validationErrors.message());
+        }
+    }
 }
 
 isolated function parseConstraintErrors(string message) returns string[] {


### PR DESCRIPTION
## Purpose
PR to refactor the existing `validate()` function in `health.fhir.r4.validator` to add terminology validation functionality to the validate operations.

## Goals
Enhance the validation functionality by adding terminology validation