### PR TITLE
Fix typo issue that causes incorrect substring index

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
@@ -38,7 +38,7 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
                 r4:FHIRContext fhirContext;
                 if isOperationPath(paths) {
                     string fhirResource = apiConfig.resourceType;
-                    string operation = paths[path.length() - 1].substring(1);
+                    string operation = paths[paths.length() - 1].substring(1);
                     log:printDebug(string `Processing operation: ${operation}`);
                     r4:FHIRInteractionLevel operationScope = getRequestOperationScope(operation, fhirResource, paths);
                     if hasPathParam { // Instance level operation


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> Fix operation fetching issue
Logs from previous version
```
time=2025-04-21T12:24:16.051+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Request paths:  [\"fhir\",\"r4\",\"Group\",\"abc\",\"$export\"]"
time=2025-04-21T12:24:16.056+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Processing operation: roup"
time=2025-04-21T12:24:16.057+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Pre-processing FHIR operation : roup"
time=2025-04-21T12:24:16.091+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Execute: FHIR Response Error Interceptor"
```

Logs from fixed version
```
time=2025-04-21T13:38:52.917+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Request paths:  [\"fhir\",\"r4\",\"Group\",\"abc\",\"$export\"]"
time=2025-04-21T13:38:52.919+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Processing operation: export"
time=2025-04-21T13:38:52.921+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Pre-processing FHIR operation : export"
time=2025-04-21T13:38:52.926+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Processing resource bound operation: export"
time=2025-04-21T13:38:52.926+05:30 level=DEBUG module=ballerinax/health.fhirr4 message="Processing GET invoked operation params of operation: export"
```
