### PR TITLE
Add new FHIR structure definitions in fhir_registry.bal

### DIFF
--- a/r4/Ballerina.toml
+++ b/r4/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "health.fhir.r4"
-version = "6.0.1"
+version = "6.0.2"
 distribution = "2201.12.2"
 authors = ["Ballerina"]
 keywords = ["Healthcare", "FHIR", "R4"]

--- a/r4/Dependencies.toml
+++ b/r4/Dependencies.toml
@@ -364,7 +364,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/r4/fhir_registry.bal
+++ b/r4/fhir_registry.bal
@@ -40,6 +40,16 @@ public isolated class FHIRRegistry {
             url: "http://hl7.org/fhir/StructureDefinition/ValueSet",
             resourceType: "ValueSet",
             modelType: ValueSet
+        },
+        "http://hl7.org/fhir/StructureDefinition/shareablecodesystem": {
+            url: "http://hl7.org/fhir/StructureDefinition/shareablecodesystem",
+            resourceType: "CodeSystem",
+            modelType: CodeSystem
+        },
+        "http://hl7.org/fhir/StructureDefinition/shareablevalueset": {
+            url: "http://hl7.org/fhir/StructureDefinition/shareablevalueset",
+            resourceType: "ValueSet",
+            modelType: ValueSet
         }
     };
 


### PR DESCRIPTION
## Purpose
PR to add `sharableCodeSystem` and `shareableValueSet` FHIR structure definitions to the `health.fhir.r4` FHIR registry.

Issue: [#44103](https://github.com/ballerina-platform/ballerina-lang/issues/44103)