### PR TITLE
Refactor terminology operations to support custom source implementations

### DIFF
--- a/terminology/Ballerina.toml
+++ b/terminology/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "health.fhir.r4.terminology"
 version = "5.0.1"
-distribution = "2201.12.2"
+distribution = "2201.12.3"
 authors = ["Ballerina"]
 keywords = ["Healthcare", "FHIR", "R4", "Terminology"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-health.fhir.r4"

--- a/terminology/Dependencies.toml
+++ b/terminology/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.2"
+distribution-version = "2201.12.3"
 
 [[package]]
 org = "ballerina"

--- a/terminology/Dependencies.toml
+++ b/terminology/Dependencies.toml
@@ -69,8 +69,19 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "ftp"
+version = "2.13.1"
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "task"}
+]
+
+[[package]]
+org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -279,10 +290,11 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.7.0"
+version = "2.11.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
 ]
 
 [[package]]
@@ -330,9 +342,18 @@ dependencies = [
 ]
 
 [[package]]
+org = "ballerinai"
+name = "observe"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "observe"}
+]
+
+[[package]]
 org = "ballerinax"
 name = "health.base"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
@@ -345,8 +366,26 @@ dependencies = [
 
 [[package]]
 org = "ballerinax"
+name = "health.clients.fhir"
+version = "3.0.0"
+dependencies = [
+	{org = "ballerina", name = "file"},
+	{org = "ballerina", name = "ftp"},
+	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"},
+	{org = "ballerina", name = "uuid"},
+	{org = "ballerinai", name = "observe"},
+	{org = "ballerinax", name = "health.base"}
+]
+
+[[package]]
+org = "ballerinax"
 name = "health.fhir.r4"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -367,7 +406,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4.international401"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "log"},
@@ -380,12 +419,13 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4.parser"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
+	{org = "ballerinax", name = "health.clients.fhir"},
 	{org = "ballerinax", name = "health.fhir.r4"},
 	{org = "ballerinax", name = "health.fhir.r4.international401"}
 ]
@@ -413,12 +453,13 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4.validator"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.regexp"},
 	{org = "ballerina", name = "log"},
+	{org = "ballerinax", name = "health.clients.fhir"},
 	{org = "ballerinax", name = "health.fhir.r4"},
 	{org = "ballerinax", name = "health.fhir.r4.international401"},
 	{org = "ballerinax", name = "health.fhir.r4.parser"}


### PR DESCRIPTION
## Purpose
This PR refactors terminology operations in the `ballerinax/health.fhir.r4.terminology` library to support database-connected terminology sources in addition to the existing in-memory model.

Resolves:
- https://github.com/ballerina-platform/ballerina-library/issues/7930

Updated Functions

- `codeSystemLookup()`: Rewritten to delegate code lookup to `findConcept(system, code)` defined in the terminology source abstraction.
- `valueSetLookup()`: Updated to fetch concepts using the unified retrieval mechanism for improved consistency and support for DB-backed value sets.
- `subsumes()`: Refactored to use backend-agnostic concept resolution logic.

Lookup functions now rely on the `findConcept()` method from the terminology source implementation instead of directly accessing CodeSystem.concept or ValueSet.compose.include.concept.

Function behaviour is now uniform regardless of source type (in-memory vs DB).

## Goals
Abstract concept retrieval using a `findConcept(system, code)` method to decouple terminology logic from specific data sources.
Enable consistent behaviour for terminology operations across both in-memory and database-connected environments.
Improve maintainability and scalability for large terminology datasets like LOINC and SNOMED CT.

## Documentation
[Design Document: Refactoring the Terminology Library to Support Database-Connected Terminology Sources](https://docs.google.com/document/d/1cUmMckLMdgZfyH7cn22x2Kv49xZV4M-mEapU--a4uCg/edit?usp=sharing)

## Automation tests
 - Unit tests 
   Coverage: 87.21% (post-refactor)
   Several unit tests were updated to improve assertions or accommodate changes in operation behaviour.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment

- Open JDK 21.0.6 2025-01-21 LTS
- Windows 11
- Ballerina Swan Lake 2201.12.3