### PR TITLE
Fix: Improve $subsumes Operation to Support Full FHIR Subsumption Outcomes

### DIFF
--- a/terminology/constants.bal
+++ b/terminology/constants.bal
@@ -59,6 +59,11 @@ public const FILTER = "filter";
 public const DISPLAY = "display";
 public const DEFINITION = "definition";
 public const OUTCOME = "outcome";
-public const EQUIVALENT = "equivalent";
-public const NOT_SUBSUMED = "not-subsumed";
 public const DEFAULT_VERSION = "0.0.0";
+
+public enum CodeSystemSubsumption {
+    EQUIVALENT = "equivalent",
+    NOT_SUBSUMED = "not-subsumed",
+    SUBSUMED = "subsumed",
+    SUBSUMED_BY = "subsumed-by"
+}

--- a/terminology/terminology.bal
+++ b/terminology/terminology.bal
@@ -451,11 +451,30 @@ public isolated function subsumes(r4:code|r4:Coding conceptA, r4:code|r4:Coding 
     r4:CodeSystemConcept? conceptDetailsB = check retrieveCodeSystemConcept(codeSystem, conceptB.clone());
 
     if conceptDetailsA != () && conceptDetailsB != () {
-        if conceptDetailsA.code == conceptDetailsB.code && conceptDetailsA.display == conceptDetailsB.display {
+        if conceptDetailsA.code == conceptDetailsB.code {
             return {'parameter: [{name: OUTCOME, valueCode: EQUIVALENT}]};
         } else {
+            // check is conceptA is subsumed by conceptB
+            r4:CodeSystemConcept[]? conceptDetailsAConcepts = conceptDetailsA.concept;
+            if conceptDetailsAConcepts is r4:CodeSystemConcept[] {
+                // check whether the concept B in the concept A's concept list
+                if isAChildConcept(conceptDetailsB.code, conceptDetailsAConcepts) {
+                    return {'parameter: [{name: OUTCOME, valueCode: SUBSUMED}]};
+                }
+            }
+
+            // check is conceptB is subsumed by conceptA
+            r4:CodeSystemConcept[]? conceptDetailsBConcepts = conceptDetailsB.concept;
+            if conceptDetailsBConcepts is r4:CodeSystemConcept[] {
+                // check whether the concept A in the concept B's concept list
+                if isAChildConcept(conceptDetailsA.code, conceptDetailsBConcepts) {
+                    return {'parameter: [{name: OUTCOME, valueCode: SUBSUMED_BY}]};
+                }
+            }
+
             return {'parameter: [{name: OUTCOME, valueCode: NOT_SUBSUMED}]};
         }
+        
     } else if conceptDetailsA is () {
         return r4:createFHIRError(
                     string `Code/ Coding: ${conceptA.toString()} is not included in the provided CodeSystem`,

--- a/terminology/tests/terminology_test.bal
+++ b/terminology/tests/terminology_test.bal
@@ -1265,6 +1265,54 @@ function codesystemSubsumeTest5() returns error? {
 }
 
 @test:Config {
+    groups: ["codesystem", "codesystem_subsume", "recursive_codesystem"]
+}
+function codesystemSubsumeTest6() returns error? {
+    // "A" is the parent of "A1"
+    r4:code codeA = "A";
+    r4:code codeB = "A1";
+    TestTerminology customTerminology = new ();
+    i4:Parameters|r4:FHIRError actualResult = subsumes(codeA, codeB, system = "http://example.org/recursive-codesystem", terminology = customTerminology);
+    test:assertTrue(actualResult is i4:Parameters, "Expected Parameters result");
+    if actualResult is i4:Parameters {
+        i4:ParametersParameter actual = (<i4:ParametersParameter[]>actualResult.'parameter)[0];
+        test:assertEquals(actual.valueCode, "subsumed");
+    }
+}
+
+@test:Config {
+    groups: ["codesystem", "codesystem_subsume", "recursive_codesystem"]
+}
+function codesystemSubsumeTest7() returns error? {
+    // "A1a" and "A2" are not in a parent-child relationship (different branches)
+    r4:code codeA = "A1a";
+    r4:code codeB = "A2";
+    TestTerminology customTerminology = new ();
+    i4:Parameters|r4:FHIRError actualResult = subsumes(codeA, codeB, system = "http://example.org/recursive-codesystem", terminology = customTerminology);
+    test:assertTrue(actualResult is i4:Parameters, "Expected Parameters result");
+    if actualResult is i4:Parameters {
+        i4:ParametersParameter actual = (<i4:ParametersParameter[]>actualResult.'parameter)[0];
+        test:assertEquals(actual.valueCode, "not-subsumed");
+    }
+}
+
+@test:Config {
+    groups: ["codesystem", "codesystem_subsume", "recursive_codesystem"]
+}
+function codesystemSubsumeTest8() returns error? {
+    // "A" is the parent of "A1"
+    r4:code codeA = "A1";
+    r4:code codeB = "A";
+    TestTerminology customTerminology = new ();
+    i4:Parameters|r4:FHIRError actualResult = subsumes(codeA, codeB, system = "http://example.org/recursive-codesystem", terminology = customTerminology);
+    test:assertTrue(actualResult is i4:Parameters, "Expected Parameters result");
+    if actualResult is i4:Parameters {
+        i4:ParametersParameter actual = (<i4:ParametersParameter[]>actualResult.'parameter)[0];
+        test:assertEquals(actual.valueCode, "subsumed-by");
+    }
+}
+
+@test:Config {
     groups: ["codesystem", "add_codesystem", "failure_scenario"]
 }
 function addCodeSystem1() {

--- a/terminology/tests/terminology_test_utils.bal
+++ b/terminology/tests/terminology_test_utils.bal
@@ -64,6 +64,66 @@ isolated class TestTerminology {
     private map<r4:ValueSet> valueSetMap = {};
 
     function init() {
+        // Add a CodeSystem object for http://xyz.org
+        r4:CodeSystem csXyz = {
+            id: "cs-xyz",
+            status: "active",
+            url: "http://xyz.org",
+            version: "2.36",
+            content: "complete",
+            concept: [
+                {code: "1", display: "Cholesterol xyz [Moles/Volume]"},
+                {code: "2", display: "Cholesterol xyz [Mass/Volume]"}
+            ]
+        };
+        // Add a CodeSystem object with the given concepts and extra concepts
+        r4:CodeSystem csLoinc = {
+            id: "loinc",
+            status: "active",
+            url: "http://loinc.org",
+            version: "2.36",
+            content: "complete",
+            concept: [
+                {code: "1", display: "Cholesterol [Moles/Volume]"},
+                {code: "2", display: "Cholesterol [Mass/Volume]"},
+                {code: "3", display: "Triglyceride [Moles/Volume]"},
+                {code: "4", display: "Triglyceride [Mass/Volume]"},
+                {code: "5", display: "HDL Cholesterol [Moles/Volume]"}
+            ]
+        };
+        r4:CodeSystem csRecursive = {
+            id: "cs-recursive",
+            status: "active",
+            url: "http://example.org/recursive-codesystem",
+            version: "1.0.0",
+            content: "complete",
+            concept: [
+                {
+                    code: "A",
+                    display: "Parent A",
+                    concept: [
+                        {
+                            code: "A1",
+                            display: "Child A1",
+                            concept: [
+                                {
+                                    code: "A1a",
+                                    display: "Grandchild A1a"
+                                }
+                            ]
+                        },
+                        {
+                            code: "A2",
+                            display: "Child A2"
+                        }
+                    ]
+                },
+                {
+                    code: "B",
+                    display: "Parent B"
+                }
+            ]
+        };
         r4:ValueSet vs1 = {id: "vs1", status: "active", url: "http://example.org/vs1", version: "1.0.0", compose: {include: []}};
         vs1.compose.include = [{valueSet: ["http://example.org/vs2"]}];
         r4:ValueSet vs2 = {id: "vs2", status: "active", url: "http://example.org/vs2", version: "1.0.0", compose: {include: []}};
@@ -124,6 +184,9 @@ isolated class TestTerminology {
             self.valueSetMap["http://example.org/vs2"] = vs2.clone();
             self.valueSetMap["http://example.org/vs3"] = vs3.clone();
             self.valueSetMap["http://example.org/vs4"] = vs4.clone();
+            self.codeSystemMap["http://loinc.org"] = csLoinc.clone();
+            self.codeSystemMap["http://xyz.org"] = csXyz.clone();
+            self.codeSystemMap["http://example.org/recursive-codesystem"] = csRecursive.clone();
         }
     }
 

--- a/terminology/utils.bal
+++ b/terminology/utils.bal
@@ -448,6 +448,20 @@ isolated function modifySearchParamsWithPagination(map<r4:RequestSearchParameter
     };
 }
 
+isolated function isAChildConcept(r4:code targetCode, r4:CodeSystemConcept[] conceptsInCurrentConcept) returns boolean {
+    foreach r4:CodeSystemConcept currentConcept in conceptsInCurrentConcept {
+        if currentConcept.code == targetCode {
+            return true;
+        }
+        if currentConcept.concept is r4:CodeSystemConcept[] {
+            if isAChildConcept(targetCode, <r4:CodeSystemConcept[]>currentConcept.concept) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 type PaginationSearchParamsResponse record {
     map<r4:RequestSearchParameter[]> searchParameters;
     int count;


### PR DESCRIPTION
## Purpose
This PR enhances the existing $subsumes operation to return all valid FHIR-defined subsumption outcomes:

- equivalent
- subsumes
- subsumed-by
- not-subsumed

The previous implementation only compared code and display fields for equality and returned either equivalent or not-subsumed.

Resolved: [#7935](https://github.com/ballerina-platform/ballerina-library/issues/7935)

## Approach

- Recursively checks the concept hierarchy in the CodeSystem resource to determine subsumption relationships.
- Uses a helper function isAChildConcept() to search the descendant tree.
- Returns appropriate outcome codes based on whether codeA is an ancestor/descendant/same as codeB.