### PR TITLE
Fix typo issue that causes incorrect substring index

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
@@ -177,7 +177,7 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
                     if payload is json || payload is http:NoContentError {
                         // An operation with no parameters but affects the state is invoked using an empty body
                         json? operationPayload = payload is http:NoContentError ? () : payload;
-                        string operation = paths[path.length() - 1].substring(1);
+                        string operation = paths[paths.length() - 1].substring(1);
                         r4:FHIRInteractionLevel operationScope = getRequestOperationScope(operation,
                                 fhirResource, paths);
                         if isHavingPathParam(resourceMethod) { // Instance level operation 


### PR DESCRIPTION
## Purpose
> Populate the fix applied for GET resource handler into POST resource handler as well. Since FHIR Operations can be called on both GET and POST requests.

## Related PRs
> https://github.com/ballerina-platform/module-ballerinax-health.fhir.r4/pull/501