### PR TITLE
[Analytics] Add support to publish logs to a remote server

### DIFF
--- a/fhirr4/ballerina/pom.xml
+++ b/fhirr4/ballerina/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -148,8 +148,8 @@
                                     <executable>bal</executable>
                                     <arguments>
                                         <argument>test</argument>
-<!--                                        <argument>&#45;&#45;test-report</argument>-->
-<!--                                        <argument>&#45;&#45;code-coverage</argument>-->
+                                        <!--                                        <argument>&#45;&#45;test-report</argument>-->
+                                        <!--                                        <argument>&#45;&#45;code-coverage</argument>-->
                                         <argument>${project.build.outputDirectory}/fhirservice</argument>
                                     </arguments>
                                 </configuration>

--- a/fhirr4/ballerina/src/main/resources/fhirservice/README.md
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/README.md
@@ -6,22 +6,22 @@ Ballerina FHIR service type can be used for developing FHIR APIs. It provides a 
 
 ## Capabilitites and features
 
-* Validating search parameters.
-* Parsing and validating the request payload when creating FHIR resources.
-* Validating content-related headers.
-* Executing post-processing logic that can be plugged in.
-* Handling errors in all these validations and responding an operation outcome.
+- Validating search parameters.
+- Parsing and validating the request payload when creating FHIR resources.
+- Validating content-related headers.
+- Executing post-processing logic that can be plugged in.
+- Handling errors in all these validations and responding an operation outcome.
 
 ## Sample Usage
 
-* Import the required packages.
+- Import the required packages.
 
 ```ballerina
-import ballerinax/health.fhirr4; 
-import ballerinax/health.fhir.r4; 
+import ballerinax/health.fhirr4;
+import ballerinax/health.fhir.r4;
 ```
 
-* Create a `ResourceAPIConfig` record similar to the following.
+- Create a `ResourceAPIConfig` record similar to the following.
 
 ```ballerina
 final r4:ResourceAPIConfig apiConfig = {
@@ -65,7 +65,7 @@ final r4:ResourceAPIConfig apiConfig = {
 };
 ```
 
-* Define a FHIR service similar to the following by passing the api-config record created in the previous step.
+- Define a FHIR service similar to the following by passing the api-config record created in the previous step.
 
 ```ballerina
 service / on new fhirr4:Listener(9090, apiConfig) {
@@ -76,3 +76,7 @@ service / on new fhirr4:Listener(9090, apiConfig) {
     }
 }
 ```
+
+## Analytics with FHIR R4 service
+
+Refer to `resources/analytics_README.md`

--- a/fhirr4/ballerina/src/main/resources/fhirservice/analytics_request_interceptor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/analytics_request_interceptor.bal
@@ -1,0 +1,154 @@
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/jwt;
+import ballerina/log;
+import ballerina/time;
+import ballerinax/health.fhir.r4;
+
+configurable boolean analytics_enabled = false;
+
+// OpenSearch configuration
+configurable string opensearch_url = "http://localhost:9200";
+configurable string opensearch_index = "healthcare-logs";
+configurable string opensearch_username = "";
+configurable string opensearch_password = "";
+
+// Configs to read from x-jwt-assertion header
+configurable string[] x_jwt_attributes = ["fhirUser", "client_id", "iss"];
+
+// Configs to get more information about the patient
+configurable boolean get_more_info = false;
+configurable string more_info_url = "";
+configurable string more_info_username = "";
+configurable string more_info_password = "";
+
+const X_JWT_HEADER = "x-jwt-assertion";
+
+isolated service class AnalyticsRequestInterceptor {
+    *http:RequestInterceptor;
+    final string resourceType;
+
+    public function init(r4:ResourceAPIConfig apiConfig) {
+        self.resourceType = apiConfig.resourceType;
+    }
+
+    isolated function sendToOpenSearch(json logData) returns error? {
+
+        string url = opensearch_url + "/" + opensearch_index + "/_doc";
+        log:printDebug("[AnalyticsRequestInterceptor] Sending log to: " + url + " with index: " + opensearch_index);
+
+        http:Client openSearchClient;
+        if opensearch_username != "" && opensearch_password != "" {
+            openSearchClient = check new (url, auth = {
+                username: opensearch_username,
+                password: opensearch_password
+            });
+        } else {
+            openSearchClient = check new (url);
+        }
+
+        http:Response result = check openSearchClient->post("", logData);
+        if result.statusCode < 200 || result.statusCode >= 300 {
+            log:printError("[AnalyticsRequestInterceptor] Failed publishing log to " + url + " with Index: " + opensearch_index + " \nError: " + result.reasonPhrase);
+        }
+        else {
+            log:printInfo("[AnalyticsRequestInterceptor] Log published successfully to " + url + " with Index: " + opensearch_index);
+        }
+    }
+
+    isolated function getMoreInfo(string patientId) returns json|error {
+        http:Client moreInfoClient;
+        if more_info_username != "" && more_info_password != "" {
+            moreInfoClient = check new (more_info_url, auth = {
+                username: more_info_username,
+                password: more_info_password
+            });
+        } else {
+            moreInfoClient = check new (more_info_url);
+        }
+        json moreInfoResponse = check moreInfoClient->get("?patientId=" + patientId);
+        return moreInfoResponse;
+    }
+
+    isolated function publishAnalyticsData(string jwt) returns error? {
+
+        [jwt:Header, jwt:Payload]|error decodedJWT = jwt:decode(jwt);
+        if decodedJWT is [jwt:Header, jwt:Payload] {
+            [jwt:Header, jwt:Payload] [_, payload] = decodedJWT;
+
+            // Filter logData to include only keys in x_jwt_attributes
+            map<string> filteredLogData = {};
+            foreach string attr in x_jwt_attributes {
+                if payload[attr] !== () {
+                    filteredLogData[attr] = payload[attr].toString();
+                }
+            }
+
+            filteredLogData["timestamp"] = time:utcToString(time:utcNow());
+
+            filteredLogData["resourceType"] = self.resourceType;
+
+            // Get more information of fhirUser
+            if get_more_info {
+                string? fhirUser = filteredLogData["fhirUser"];
+                if fhirUser is string {
+                    json|error moreInfo = self.getMoreInfo(fhirUser);
+                    if moreInfo is json {
+                        log:printDebug("[AnalyticsRequestInterceptor] More info fetched for fhirUser: " + fhirUser);
+                        foreach var [key, value] in (<map<json>>moreInfo).entries() {
+                            filteredLogData[key] = value.toString();
+                        }
+                    } else {
+                        log:printError("[AnalyticsRequestInterceptor] Failed to fetch more info for fhirUser: " + fhirUser + ". Error: " + moreInfo.toString());
+                    }
+                }
+                else {
+                    log:printDebug("[AnalyticsRequestInterceptor] No fhirUser found in JWT, skipping more info fetch.");
+                }
+            }
+
+            log:printDebug("[AnalyticsRequestInterceptor] Publishing log" + filteredLogData.toString());
+            check self.sendToOpenSearch(filteredLogData.toJson());
+        } else {
+            log:printError("[AnalyticsRequestInterceptor] Error decoding x-jwt-assertion header.");
+        }
+
+    }
+
+    isolated resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
+
+        if !analytics_enabled {
+            log:printDebug("[AnalyticsRequestInterceptor] Analytics is disabled. Skipping analytics data publishing.");
+            return ctx.next();
+        }
+
+        string|error xJWT = req.getHeader(X_JWT_HEADER);
+        if (xJWT is error) {
+            log:printError("[AnalyticsRequestInterceptor] Failed publishing logs. Error: Missing x-jwt-assertion header.");
+            return ctx.next();
+        }
+
+        log:printDebug("[AnalyticsRequestInterceptor] Publishing analytics data.");
+        future<error?> _ = start self.publishAnalyticsData(xJWT);
+
+        // Returns the next interceptor in the pipeline.
+        return ctx.next();
+    }
+
+}
+

--- a/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
@@ -22,8 +22,8 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
         private final Holder holder = h;
         private final FHIRPreprocessor preprocessor = new (apiConfig);
 
-        public function createInterceptors() returns [FHIRResponseErrorInterceptor, FHIRResponseInterceptor, AnalyticsRequestInterceptor] {
-            return [new FHIRResponseErrorInterceptor(), new FHIRResponseInterceptor(apiConfig), new AnalyticsRequestInterceptor(apiConfig)];
+        public function createInterceptors() returns [FHIRResponseErrorInterceptor, FHIRResponseInterceptor, AnalyticsResponseInterceptor] {
+            return [new FHIRResponseErrorInterceptor(), new FHIRResponseInterceptor(apiConfig), new AnalyticsResponseInterceptor(apiConfig)];
         }
 
         isolated resource function get [string... path](http:Request req, http:RequestContext ctx) returns any|error {

--- a/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/http_service_builder.bal
@@ -22,8 +22,8 @@ isolated function getHttpService(Holder h, r4:ResourceAPIConfig apiConfig, strin
         private final Holder holder = h;
         private final FHIRPreprocessor preprocessor = new (apiConfig);
 
-        public function createInterceptors() returns [FHIRResponseErrorInterceptor, FHIRResponseInterceptor] {
-            return [new FHIRResponseErrorInterceptor(), new FHIRResponseInterceptor(apiConfig)];
+        public function createInterceptors() returns [FHIRResponseErrorInterceptor, FHIRResponseInterceptor, AnalyticsRequestInterceptor] {
+            return [new FHIRResponseErrorInterceptor(), new FHIRResponseInterceptor(apiConfig), new AnalyticsRequestInterceptor(apiConfig)];
         }
 
         isolated resource function get [string... path](http:Request req, http:RequestContext ctx) returns any|error {

--- a/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
@@ -8,15 +8,15 @@ This is achieved through the `AnalyticsRequestInterceptor` which can intercept t
 
 Inside the module which imports `ballerinax.health.fhirr4`, we need to have a `Config.toml` at the same level as `Ballerina.toml` including the necessary configs. A sample Config.toml can be found in `sample_config.toml`. Following is a clarification on those configs.
 
-> `analyticsEnabled` : To enable publishing logs to the configured analytics server
-> `analyticsRequiredAttributes` : Only the attributes listed here are taken from the jwt (`x-jwt-assertion` header value) to publish
-> `analyticsServerUrl` : Hosted analytics server url
-> `analyticsServerUsername` : BasicAuth username for the analytics server
-> `analyticsServerPassword` : BasicAuth password for the analytics server
-> `analyticsMoreInfoRequired` : Whether more information is required
-> `analyticsMoreInfoUrl` : An api to fetch more information required for analytics
-> `analyticsMoreInfoUsername` : BasicAuth username for more info api
-> `analyticsMoreInfoPassword` : BasicAuth password for more info api
+> - `analyticsEnabled` : To enable publishing logs to the configured analytics server
+> - `analyticsRequiredAttributes` : Only the attributes listed here are taken from the jwt (`x-jwt-assertion` header value) to publish
+> - `analyticsServerUrl` : Hosted analytics server url
+> - `analyticsServerUsername` : BasicAuth username for the analytics server
+> - `analyticsServerPassword` : BasicAuth password for the analytics server
+> - `analyticsMoreInfoRequired` : Whether more information is required
+> - `analyticsMoreInfoUrl` : An api to fetch more information required for analytics
+> - `analyticsMoreInfoUsername` : BasicAuth username for more info api
+> - `analyticsMoreInfoPassword` : BasicAuth password for more info api
 
 ### x-jwt-assertion Header :
 

--- a/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
@@ -4,9 +4,9 @@ FHIR R4 service comes with inbuilt analytics service, which can publish analytic
 
 This is achieved through the `AnalyticsRequestInterceptor` which can intercept the received requests, collect the required attribute values and publishing to the configured `analyticsServerUrl`.
 
-## Configuraing Analytics
+## Configuring Analytics
 
-Inside the module which imports `ballerinax.health.fhirr4`, we need to have a `Config.toml` at the same level as `Ballerina.toml` including the necessary configs. A sample Config.toml can be found in `sample_config.toml`. Following is a clarification on those configs.
+Inside the module which imports `ballerinax.health.fhirr4`, we need to have a `Config.toml` at the same level as `Ballerina.toml` including the necessary configs. Following is a clarification on those configs.
 
 > - `analyticsEnabled` : To enable publishing logs to the configured analytics server
 > - `analyticsRequiredAttributes` : Only the attributes listed here are taken from the jwt (`x-jwt-assertion` header value) to publish
@@ -26,12 +26,12 @@ The data which is published for analytics are taken from the `x-jwt-assertion` h
 
 Analytics server can be any server which can capture analytics logs using API requests. AnalyticsRequestInterceptor only supports JSON format, where it sends logs as a JSON with string values to the configured server. Currently only Basic Auth is used (if configured) for api security.
 
-`Opensearch` & `Opensearch Dashboards` are recommended for capture logs, analyze and visualize.
+For example `Opensearch` & `Opensearch Dashboards` can be used to capture logs, analyze and visualize.
 
 ### More Info API :
 
-There can be information which are out of scope for the FHIR server, but may be required for analytics. We can expose these info using an API (POST request) which accepts a json with `requiredAttributes` as keys, and returns more info as a json with key:\<string>value pairs.
+There can be information which are out of scope for the FHIR server, but may be required for analytics. The party which uses FHIR analytics can expose these info using an API (POST endpoint) which accepts a json with `requiredAttributes` as keys, and returns more info as a json with key:\<string>value pairs.
 
 Check `more_info_api.yaml` for an open-api sample swagger.
 
-> Note: The keys of the json response of the more info api (contract and plan in the above example) should not change per request since analytics servers like Opensearch creates the index patterns at the very first log publishing request, and any new keys sent later will not be persisted under that index pattern.
+> Note: The keys of the json response of the more info api should not change per request since analytics servers like Opensearch creates the index patterns at the very first log publishing request, and any new keys sent later will not be persisted under that index pattern.

--- a/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
@@ -1,0 +1,37 @@
+# Analytics with FHIR R4 service
+
+FHIR R4 service comes with inbuilt analytics service, which can publish analytics logs to a configured server using a REST API call.
+
+This is achieved through the `AnalyticsRequestInterceptor` which can intercept the received requests, collect the required attribute values and publishing to the configured `analyticsServerUrl`.
+
+## Configuraing Analytics
+
+Inside the module which imports `ballerinax.health.fhirr4`, we need to have a `Config.toml` at the same level as `Ballerina.toml` including the necessary configs. A sample Config.toml can be found in `sample_config.toml`. Following is a clarification on those configs.
+
+> `analyticsEnabled` : To enable publishing logs to the configured analytics server
+> `analyticsRequiredAttributes` : Only the attributes listed here are taken from the jwt (`x-jwt-assertion` header value) to publish
+> `analyticsServerUrl` : Hosted analytics server url
+> `analyticsServerUsername` : BasicAuth username for the analytics server
+> `analyticsServerPassword` : BasicAuth password for the analytics server
+> `analyticsMoreInfoRequired` : Whether more information is required
+> `analyticsMoreInfoUrl` : An api to fetch more information required for analytics
+> `analyticsMoreInfoUsername` : BasicAuth username for more info api
+> `analyticsMoreInfoPassword` : BasicAuth password for more info api
+
+### x-jwt-assertion Header :
+
+The data which is published for analytics are taken from the `x-jwt-assertion` header coming in the http request. Only the attributes in the `analyticsRequiredAttributes` list are published.
+
+### Analytics Server :
+
+Analytics server can be any server which can capture analytics logs using API requests. AnalyticsRequestInterceptor only supports JSON format, where it sends logs as a JSON with string values to the configured server. Currently only Basic Auth is used (if configured) for api security.
+
+`Opensearch` & `Opensearch Dashboards` are recommended for capture logs, analyze and visualize.
+
+### More Info API :
+
+There can be information which are out of scope for the FHIR server, but may be required for analytics. We can expose these info using an API (POST request) which accepts a json with `requiredAttributes` as keys, and returns more info as a json with key:\<string>value pairs.
+
+Check `more_info_api.yaml` for an open-api sample swagger.
+
+> Note: The keys of the json response of the more info api (contract and plan in the above example) should not change per request since analytics servers like Opensearch creates the index patterns at the very first log publishing request, and any new keys sent later will not be persisted under that index pattern.

--- a/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_README.md
@@ -2,35 +2,42 @@
 
 FHIR R4 service comes with inbuilt analytics service, which can publish analytics logs to a configured server using a REST API call.
 
-This is achieved through the `AnalyticsRequestInterceptor` which can intercept the received requests, collect the required attribute values and publishing to the configured `analyticsServerUrl`.
+This is achieved through the `AnalyticsResponseInterceptor` which can intercept the outgoing responses, collect the required attribute values and publishing to the configured Analytics Server.
 
 ## Configuring Analytics
 
 Inside the module which imports `ballerinax.health.fhirr4`, we need to have a `Config.toml` at the same level as `Ballerina.toml` including the necessary configs. Following is a clarification on those configs.
 
-> - `analyticsEnabled` : To enable publishing logs to the configured analytics server
-> - `analyticsRequiredAttributes` : Only the attributes listed here are taken from the jwt (`x-jwt-assertion` header value) to publish
-> - `analyticsServerUrl` : Hosted analytics server url
-> - `analyticsServerUsername` : BasicAuth username for the analytics server
-> - `analyticsServerPassword` : BasicAuth password for the analytics server
-> - `analyticsMoreInfoRequired` : Whether more information is required
-> - `analyticsMoreInfoUrl` : An api to fetch more information required for analytics
-> - `analyticsMoreInfoUsername` : BasicAuth username for more info api
-> - `analyticsMoreInfoPassword` : BasicAuth password for more info api
+```
+[ballerinax.health.fhirr4.analytics]
+```
+> - `enabled` : To enable publishing logs to the configured analytics server
+> - `attributes` : Only the attributes listed here are taken from the jwt (`x-jwt-assertion` header value) to publish
+> - `url` : Analytics server url
+> - `username` : BasicAuth username for the analytics server
+> - `password` : BasicAuth password for the analytics server
+
+```
+[ballerinax.health.fhirr4.analytics.moreInfo]
+```
+> - `enabled` : Whether more information is required or not
+> - `url` : An api to fetch more information required for analytics
+> - `username` : BasicAuth username for more info api
+> - `password` : BasicAuth password for more info api
 
 ### x-jwt-assertion Header :
 
-The data which is published for analytics are taken from the `x-jwt-assertion` header coming in the http request. Only the attributes in the `analyticsRequiredAttributes` list are published.
+The data which is published for analytics are taken mostly from the `x-jwt-assertion` header coming in the http request. Only the attributes in the `ballerinax.health.fhirr4.analytics.attributes` list are published.
 
 ### Analytics Server :
 
-Analytics server can be any server which can capture analytics logs using API requests. AnalyticsRequestInterceptor only supports JSON format, where it sends logs as a JSON with string values to the configured server. Currently only Basic Auth is used (if configured) for api security.
+Analytics server can be any server which can capture analytics logs using API requests. AnalyticsResponseInterceptor only supports JSON format, where it sends logs as a JSON with string values to the configured server. Currently only Basic Auth is used (if configured) for api security.
 
 For example `Opensearch` & `Opensearch Dashboards` can be used to capture logs, analyze and visualize.
 
 ### More Info API :
 
-There can be information which are out of scope for the FHIR server, but may be required for analytics. The party which uses FHIR analytics can expose these info using an API (POST endpoint) which accepts a json with `requiredAttributes` as keys, and returns more info as a json with key:\<string>value pairs.
+There can be information which are out of scope for the FHIR server, but may be required for analytics. The party which uses FHIR analytics can expose these info using an API (POST endpoint) which accepts a json with `ballerinax.health.fhirr4.analytics.attributes` as keys, and returns more info as a json with key:\<string>value pairs.
 
 Check `more_info_api.yaml` for an open-api sample swagger.
 

--- a/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_more_info_api.yaml
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/resources/analytics_more_info_api.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: More Info API
+  version: 1.0.0
+  description: 'More Info API to get more information to publish for analytics.'
+paths:
+  /more_info:
+    post:
+      summary: Accepts and returns a JSON object with arbitrary string fields.
+      requestBody:
+        description: JSON input with arbitrary keys and string values
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        '200':
+          description: JSON output with arbitrary keys and string values
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string

--- a/fhirr4/compiler-plugin/pom.xml
+++ b/fhirr4/compiler-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/native/pom.xml
+++ b/fhirr4/native/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/pom.xml
+++ b/fhirr4/pom.xml
@@ -25,7 +25,7 @@
     <groupId>io.ballerinax</groupId>
     <artifactId>fhirr4</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <modules>
         <module>compiler-plugin</module>
         <module>native</module>


### PR DESCRIPTION
A new AnalyticsResponseInterceptor was added to intercept outgoing responses and publish logs asychronously to a configured server if enabled.

## Purpose
> $subject

## Goals
- https://github.com/wso2-enterprise/open-healthcare/issues/1740

## Approach
- Approach 3 in: https://github.com/wso2-enterprise/open-healthcare/issues/1750

## Test environment
> Ballerina: latest, Opensearch & Opensearch Dashboards: latest
 