### PR TITLE
Add Conditional Create Support for FHIR Service

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
@@ -218,6 +218,7 @@ public isolated class FHIRPreprocessor {
             // conditional create
             // Implemented according to the https://hl7.org/fhir/R4/http.html#ccreate FHIR specification
             log:printDebug("Conditional create interaction.");
+            log:printDebug(string `Conditional header (If-None-Exist): ${isNoneExistHeader}`);
             _ = check handleConditionalHeader(isNoneExistHeader);
         }
 

--- a/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
@@ -219,7 +219,7 @@ public isolated class FHIRPreprocessor {
             // Implemented according to the https://hl7.org/fhir/R4/http.html#ccreate FHIR specification
             log:printDebug("Conditional create interaction.");
             log:printDebug(string `Conditional header (If-None-Exist): ${isNoneExistHeader}`);
-            _ = check handleConditionalHeader(isNoneExistHeader);
+            _ = check handleConditionalHeader(isNoneExistHeader, httpRequest.rawPath);
         }
 
         // Set FHIR context inside HTTP context

--- a/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
@@ -213,6 +213,14 @@ public isolated class FHIRPreprocessor {
         // Create FHIR context
         r4:FHIRContext fhirCtx = new (fhirRequest, request, fhirSecurity);
 
+        string|error isNoneExistHeader = httpRequest.getHeader("If-None-Exist");
+        if isNoneExistHeader is string {
+            // conditional create
+            // Implemented according to the https://hl7.org/fhir/R4/http.html#ccreate FHIR specification
+            log:printDebug("Conditional create interaction.");
+            _ = check handleConditionalHeader(isNoneExistHeader);
+        }
+
         // Set FHIR context inside HTTP context
         setFHIRContext(fhirCtx, httpCtx);
     }

--- a/fhirr4/ballerina/src/main/resources/fhirservice/listener.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/listener.bal
@@ -46,6 +46,7 @@ public isolated class Listener {
         lock {
             self.httpService = getHttpService(holder, self.config, name is string[] ? name.cloneReadOnly() : []);
             check self.ls.attach(self.httpService, name.cloneReadOnly());
+            check createConditionalInvokationClient(self.ls.getPort());
         }
     }
 

--- a/fhirr4/ballerina/src/main/resources/fhirservice/utils.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/utils.bal
@@ -126,18 +126,10 @@ isolated function handleConditionalHeader(string conditionalUrl) returns r4:FHIR
                         httpStatusCode = http:STATUS_PRECONDITION_FAILED);
             }
         } else {
-            return r4:createFHIRError(
-                    "Invalid response received from the server",
-                    r4:ERROR,
-                    r4:INVALID,
-                    httpStatusCode = http:STATUS_BAD_REQUEST);
+            return r4:createFHIRError("Invalid response received while handling conditional search", r4:ERROR, r4:INVALID);
         }
-
     } on fail var e {
         // log the error and return a FHIR error
-    	return r4:createFHIRError(
-            "Error while handling conditional search: " + e.message(),
-            r4:ERROR,
-            r4:INVALID);
+    	return r4:createFHIRError("Error while handling conditional search: " + e.message(), r4:ERROR, r4:INVALID);
     }
 }

--- a/fhirr4/ballerina/src/main/resources/fhirservice/utils.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/utils.bal
@@ -13,6 +13,7 @@
 import ballerinax/health.fhir.r4;
 import ballerinax/health.fhir.r4.parser;
 import ballerina/http;
+import ballerina/log;
 
 isolated function addPagination(r4:PaginationContext paginationContext, map<r4:RequestSearchParameter[]> requestSearchParameters,
         r4:Bundle bundle, string path) returns r4:Bundle {
@@ -98,6 +99,7 @@ isolated function handleConditionalHeader(string conditionalUrl) returns r4:FHIR
 
         if response.statusCode == 404 {
             // allow to create a new resource if no entries are found
+            log:printDebug("No existing resource found for the given search criteria, allowing creation of a new resource");
             return;
         } 
 
@@ -109,9 +111,11 @@ isolated function handleConditionalHeader(string conditionalUrl) returns r4:FHIR
             // check the bundle entry count
             if entries.length() == 0 {
                 // allow to create a new resource if no entries are found
+                log:printDebug("No existing resource found for the given search criteria, allowing creation of a new resource");
                 return;
             } else if entries.length() == 1 {
-                // exising resource found, return the first entry
+                // exising resource found, return 200
+                log:printDebug("Existing resource found for the given search criteria, returning 200 OK");
                 return r4:createFHIRError(
                         "Resource already exists for the given search criteria",
                         r4:INFORMATION,
@@ -119,6 +123,7 @@ isolated function handleConditionalHeader(string conditionalUrl) returns r4:FHIR
                         httpStatusCode = http:STATUS_OK);
             } else {
                 // return 412 Precondition Failed if more than one entry is found
+                log:printDebug("Multiple resources found for the given search criteria, returning 412 Precondition Failed");
                 return r4:createFHIRError(
                         "Multiple resources found for the given search criteria",
                         r4:ERROR,

--- a/fhirr4/pom.xml
+++ b/fhirr4/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <ballerina.version>2201.12.1</ballerina.version>
+        <ballerina.version>2201.12.3</ballerina.version>
         <gson.version>2.8.6</gson.version>
         <international401.version>2.1.0</international401.version>
     </properties>


### PR DESCRIPTION
## Purpose
This PR introduces conditional create support to the FHIR service, aligning with the [FHIR R4 specification for conditional create](https://hl7.org/fhir/R4/http.html#ccreate). Conditional create allows clients to create a resource only if it does not already exist, based on search criteria provided in the If-None-Exist HTTP header.

- https://github.com/ballerina-platform/ballerina-library/issues/7978

## Goals

- Enable the FHIR service to process conditional create requests.
- Prevent duplicate resource creation when a matching resource already exists.
- Return appropriate FHIR-compliant responses for all conditional create scenarios.

## Approach
fhir_preprocessor.bal:

- Updated the processCreate function to check for the presence of the If-None-Exist header in incoming requests.
- If the header is present, the function invokes the new handleConditionalHeader utility to process the conditional logic before proceeding with resource creation.

utils.bal:

- Added the handleConditionalHeader function to handle the conditional create logic:
- Parses the conditional URL from the header.
- Performs a search request to check for existing resources matching the criteria.
- Returns:
  - Success if no matching resource is found (allowing creation).
  - An informational error if a single match is found (resource already exists).
  - An error if multiple matches are found (precondition failed).
- Ensures FHIR-compliant error handling and response codes.

## Automation tests
 - Unit tests 
   Coverup to 79.65%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

`international401:Patient patient = {
        resourceType: "Patient",
        name: [
            {
                "family": "Smith",
                "given": ["John"]
            }
        ],
        id: "1"
    };`
`map<string> headers = {
        "If-None-Exist": "http://localhost:9292/fhir/r4/Patient?_id=1"
    };`
`http:Response|ServiceTestError response = check fhirClient->post("/Patient", message = patient, headers = headers, mediaType = r4:FHIR_MIME_TYPE_JSON);`

## Test environment
- JDK: openjdk 21.0.6
- Ballerina: 2201.12.3
- OS: Windows 11