### PR TITLE
[FHIR-R4-LIB] [Bug Fix] Parsing Error for Extended Element Arrays Inside Base Elements

### DIFF
--- a/r4/Dependencies.toml
+++ b/r4/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.2"
+distribution-version = "2201.12.3"
 
 [[package]]
 org = "ballerina"
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -285,10 +285,11 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.7.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
 ]
 
 [[package]]
@@ -344,7 +345,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.base"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/r4/datatype_element.bal
+++ b/r4/datatype_element.bal
@@ -47,5 +47,5 @@
 public type Element record {|
     string id?;
     Extension[] extension?;
-    Element...;
+    Element | Element[]...;
 |};


### PR DESCRIPTION
## Purpose
This PR is related to [Parsing Error for Extended Element Arrays Inside Base Elements](https://github.com/ballerina-platform/ballerina-library/issues/7949). 

## Goals
To fix the parsing error occurring, when there is an extended element array, instead of a plain element, in the second level of a base type.

## Approach
The logics of the existing health-tool couldn't parse the below resource snippet from FHIR R5 ATCore (Austria) profiles. 

- Similar data fields were replicated in a FHIR R4 resource to check the possibility for such fields to be parsed correctly.

**NOTE:** Even though discovered from FHIR R5, there aren't any guarantee that FHIR R4 will totally be absent of such cases of field definitions. Therefore, the same change is transferred to FHIR R4 library too.
```
"address" : [{
    "use" : "home",
    "line" : ["Landstrasse 5 Stock 3 Tür 5"],
    "_line" : [{
      "extension" : [{
        "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
        "valueString" : "Landstrasse"
      },
      {
        "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
        "valueString" : "5"
      },
      {
        "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator",
        "valueString" : "Stock 3 Tür 5"
      },
      {
        "url" : "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0/StructureDefinition/at-core-ext-address-additionalInformation",
        "valueString" : "Lift vorhanden"
      }]
}];
```
Here the _line element has an array of extended element not a typical single element.

As array of extend elements are not restricted by FHIR definitions itself, the record for **Element** was changed to have UNION spread operator.
```
public type Element record {|
    string id?;
    Extension[] extension?;
    Element | Element[]...;
|};
```
Now even though the "Element" type is assigned by the tool, a user can parse second level extended element arrays without an issue.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Tested with local push and verified the change doesn't affect any existing package generations.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
Java: 21
Ballerina: 2201.12.3

## Test environment
JDK: 21
Ballerina: 2201.12.3
OS: Windows 11 Pro
 
## Learning
N/A