### PR TITLE
Update cardinalities of multi datatypes

### DIFF
--- a/international401/resource_actual_group.bal
+++ b/international401/resource_actual_group.bal
@@ -256,7 +256,7 @@ public enum Actual_GroupType {
         "valueCodeableConcept": {
             name: "valueCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -265,7 +265,7 @@ public enum Actual_GroupType {
         "valueBoolean": {
             name: "valueBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -301,7 +301,7 @@ public enum Actual_GroupType {
         "valueReference": {
             name: "valueReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -310,7 +310,7 @@ public enum Actual_GroupType {
         "valueRange": {
             name: "valueRange",
             dataType: r4:Range,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -346,7 +346,7 @@ public enum Actual_GroupType {
         "valueQuantity": {
             name: "valueQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",

--- a/international401/resource_audit_event.bal
+++ b/international401/resource_audit_event.bal
@@ -579,7 +579,7 @@ public type AuditEventEntity record {|
         "valueAuditEventBase64Binary": {
             name: "valueAuditEventBase64Binary",
             dataType: r4:base64Binary,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the extra detail.",
@@ -597,7 +597,7 @@ public type AuditEventEntity record {|
         "valueAuditEventString": {
             name: "valueAuditEventString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the extra detail.",

--- a/international401/resource_claim.bal
+++ b/international401/resource_claim.bal
@@ -875,7 +875,7 @@ public type ClaimSupportingInfo record {|
         "procedureCodeableConcept": {
             name: "procedureCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The code or reference to a Procedure resource which identifies the clinical intervention performed.",
@@ -893,7 +893,7 @@ public type ClaimSupportingInfo record {|
         "procedureReference": {
             name: "procedureReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The code or reference to a Procedure resource which identifies the clinical intervention performed.",
@@ -1121,7 +1121,7 @@ public type ClaimAccident record {|
         "diagnosisReference": {
             name: "diagnosisReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The nature of illness or problem in a coded form or as a reference to an external defined Condition.",
@@ -1130,7 +1130,7 @@ public type ClaimAccident record {|
         "diagnosisCodeableConcept": {
             name: "diagnosisCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The nature of illness or problem in a coded form or as a reference to an external defined Condition.",

--- a/international401/resource_clinical_document.bal
+++ b/international401/resource_clinical_document.bal
@@ -559,7 +559,7 @@ public type Clinical_DocumentAttester record {|
         "targetIdentifier": {
             name: "targetIdentifier",
             dataType: r4:Identifier,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The target composition/document of this relationship.",
@@ -595,7 +595,7 @@ public type Clinical_DocumentAttester record {|
         "targetReference": {
             name: "targetReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The target composition/document of this relationship.",

--- a/international401/resource_communication.bal
+++ b/international401/resource_communication.bal
@@ -398,7 +398,7 @@ public enum CommunicationStatus {
         "contentReference": {
             name: "contentReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A communicated content (or for multi-part communications, one portion of the communication).",
@@ -407,7 +407,7 @@ public enum CommunicationStatus {
         "contentString": {
             name: "contentString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A communicated content (or for multi-part communications, one portion of the communication).",
@@ -425,7 +425,7 @@ public enum CommunicationStatus {
         "contentAttachment": {
             name: "contentAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A communicated content (or for multi-part communications, one portion of the communication).",

--- a/international401/resource_communication_request.bal
+++ b/international401/resource_communication_request.bal
@@ -403,7 +403,7 @@ public enum CommunicationRequestPriority {
         "contentReference": {
             name: "contentReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The communicated content (or for multi-part communications, one portion of the communication).",
@@ -412,7 +412,7 @@ public enum CommunicationRequestPriority {
         "contentString": {
             name: "contentString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The communicated content (or for multi-part communications, one portion of the communication).",
@@ -430,7 +430,7 @@ public enum CommunicationRequestPriority {
         "contentAttachment": {
             name: "contentAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The communicated content (or for multi-part communications, one portion of the communication).",

--- a/international401/resource_composition.bal
+++ b/international401/resource_composition.bal
@@ -479,7 +479,7 @@ public enum CompositionAttesterMode {
         "targetIdentifier": {
             name: "targetIdentifier",
             dataType: r4:Identifier,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The target composition/document of this relationship.",
@@ -515,7 +515,7 @@ public enum CompositionAttesterMode {
         "targetReference": {
             name: "targetReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The target composition/document of this relationship.",

--- a/international401/resource_contract.bal
+++ b/international401/resource_contract.bal
@@ -506,7 +506,7 @@ public type Contract record {|
         "contentReference": {
             name: "contentReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Contract legal text in human renderable form.",
@@ -524,7 +524,7 @@ public type Contract record {|
         "contentAttachment": {
             name: "contentAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Contract legal text in human renderable form.",
@@ -1215,7 +1215,7 @@ public enum ContractStatus {
         "valueContractCoding": {
             name: "valueContractCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1224,7 +1224,7 @@ public enum ContractStatus {
         "valueContractInteger": {
             name: "valueContractInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1233,7 +1233,7 @@ public enum ContractStatus {
         "valueContractBoolean": {
             name: "valueContractBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1251,7 +1251,7 @@ public enum ContractStatus {
         "valueContractUri": {
             name: "valueContractUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1260,7 +1260,7 @@ public enum ContractStatus {
         "valueContractDate": {
             name: "valueContractDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1269,7 +1269,7 @@ public enum ContractStatus {
         "valueContractAttachment": {
             name: "valueContractAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1278,7 +1278,7 @@ public enum ContractStatus {
         "valueContractTime": {
             name: "valueContractTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1296,7 +1296,7 @@ public enum ContractStatus {
         "valueContractDecimal": {
             name: "valueContractDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1305,7 +1305,7 @@ public enum ContractStatus {
         "valueContractDateTime": {
             name: "valueContractDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1314,7 +1314,7 @@ public enum ContractStatus {
         "valueContractString": {
             name: "valueContractString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1323,7 +1323,7 @@ public enum ContractStatus {
         "valueContractQuantity": {
             name: "valueContractQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1332,7 +1332,7 @@ public enum ContractStatus {
         "valueContractReference": {
             name: "valueContractReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Response to an offer clause or question text, which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.",
@@ -1569,7 +1569,7 @@ public type ContractTerm record {|
         "contentReference": {
             name: "contentReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Human readable rendering of this Contract in a format and representation intended to enhance comprehension and ensure understandability.",
@@ -1587,7 +1587,7 @@ public type ContractTerm record {|
         "contentAttachment": {
             name: "contentAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Human readable rendering of this Contract in a format and representation intended to enhance comprehension and ensure understandability.",
@@ -2328,7 +2328,7 @@ public type ContractTermAction record {|
         "contentReference": {
             name: "contentReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Computable Contract conveyed using a policy rule language (e.g. XACML, DKAL, SecPal).",
@@ -2346,7 +2346,7 @@ public type ContractTermAction record {|
         "contentAttachment": {
             name: "contentAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Computable Contract conveyed using a policy rule language (e.g. XACML, DKAL, SecPal).",

--- a/international401/resource_coverage.bal
+++ b/international401/resource_coverage.bal
@@ -344,7 +344,7 @@ public enum CoverageStatus {
         "valueMoney": {
             name: "valueMoney",
             dataType: r4:Money,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The amount due from the patient for the cost category.",
@@ -380,7 +380,7 @@ public enum CoverageStatus {
         "valueQuantity": {
             name: "valueQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The amount due from the patient for the cost category.",

--- a/international401/resource_cqf_questionnaire.bal
+++ b/international401/resource_cqf_questionnaire.bal
@@ -390,7 +390,7 @@ public enum CQF_QuestionnaireStatus {
         "valueQuestionnaireCoding": {
             name: "valueQuestionnaireCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -426,7 +426,7 @@ public enum CQF_QuestionnaireStatus {
         "valueQuestionnaireInteger": {
             name: "valueQuestionnaireInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -435,7 +435,7 @@ public enum CQF_QuestionnaireStatus {
         "valueQuestionnaireString": {
             name: "valueQuestionnaireString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -444,7 +444,7 @@ public enum CQF_QuestionnaireStatus {
         "valueQuestionnaireDate": {
             name: "valueQuestionnaireDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -453,7 +453,7 @@ public enum CQF_QuestionnaireStatus {
         "valueQuestionnaireTime": {
             name: "valueQuestionnaireTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -462,7 +462,7 @@ public enum CQF_QuestionnaireStatus {
         "valueQuestionnaireReference": {
             name: "valueQuestionnaireReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -745,7 +745,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireReference": {
             name: "answerQuestionnaireReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -754,7 +754,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireDate": {
             name: "answerQuestionnaireDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -781,7 +781,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireDecimal": {
             name: "answerQuestionnaireDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -799,7 +799,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireTime": {
             name: "answerQuestionnaireTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -808,7 +808,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireString": {
             name: "answerQuestionnaireString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -817,7 +817,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireCoding": {
             name: "answerQuestionnaireCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -826,7 +826,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireInteger": {
             name: "answerQuestionnaireInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -835,7 +835,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireQuantity": {
             name: "answerQuestionnaireQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -853,7 +853,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireDateTime": {
             name: "answerQuestionnaireDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -862,7 +862,7 @@ public enum CQF_QuestionnaireItemEnableWhenOperator {
         "answerQuestionnaireBoolean": {
             name: "answerQuestionnaireBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -947,7 +947,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireCoding": {
             name: "valueQuestionnaireCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -965,7 +965,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireUri": {
             name: "valueQuestionnaireUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -974,7 +974,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireBoolean": {
             name: "valueQuestionnaireBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -983,7 +983,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireAttachment": {
             name: "valueQuestionnaireAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -992,7 +992,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireReference": {
             name: "valueQuestionnaireReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1001,7 +1001,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireDecimal": {
             name: "valueQuestionnaireDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1010,7 +1010,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireDateTime": {
             name: "valueQuestionnaireDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1019,7 +1019,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireQuantity": {
             name: "valueQuestionnaireQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1037,7 +1037,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireInteger": {
             name: "valueQuestionnaireInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1046,7 +1046,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireString": {
             name: "valueQuestionnaireString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1055,7 +1055,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireDate": {
             name: "valueQuestionnaireDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -1064,7 +1064,7 @@ public enum CQF_QuestionnaireItemType {
         "valueQuestionnaireTime": {
             name: "valueQuestionnaireTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",

--- a/international401/resource_device_request.bal
+++ b/international401/resource_device_request.bal
@@ -149,7 +149,7 @@ public const RESOURCE_NAME_DEVICEREQUEST = "DeviceRequest";
         "codeReference" : {
             name: "codeReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "DeviceRequest.code[x]",
@@ -338,7 +338,7 @@ public const RESOURCE_NAME_DEVICEREQUEST = "DeviceRequest";
         "codeCodeableConcept" : {
             name: "codeCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "DeviceRequest.code[x]",

--- a/international401/resource_ehrs_fm_record_lifecycle_event___audit_event.bal
+++ b/international401/resource_ehrs_fm_record_lifecycle_event___audit_event.bal
@@ -408,7 +408,7 @@ public type EHRS_FM_Record_Lifecycle_Event___Audit_EventEntity record {|
         "valueAuditEventBase64Binary": {
             name: "valueAuditEventBase64Binary",
             dataType: r4:base64Binary,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the extra detail.",
@@ -426,7 +426,7 @@ public type EHRS_FM_Record_Lifecycle_Event___Audit_EventEntity record {|
         "valueAuditEventString": {
             name: "valueAuditEventString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the extra detail.",

--- a/international401/resource_evidence_variable.bal
+++ b/international401/resource_evidence_variable.bal
@@ -449,7 +449,7 @@ public enum EvidenceVariableCharacteristicGroupMeasure {
         "definitionCodeableConcept": {
             name: "definitionCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -476,7 +476,7 @@ public enum EvidenceVariableCharacteristicGroupMeasure {
         "definitionCanonical": {
             name: "definitionCanonical",
             dataType: r4:canonical,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -494,7 +494,7 @@ public enum EvidenceVariableCharacteristicGroupMeasure {
         "definitionDataRequirement": {
             name: "definitionDataRequirement",
             dataType: r4:DataRequirement,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -530,7 +530,7 @@ public enum EvidenceVariableCharacteristicGroupMeasure {
         "definitionReference": {
             name: "definitionReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -557,7 +557,7 @@ public enum EvidenceVariableCharacteristicGroupMeasure {
         "definitionExpression": {
             name: "definitionExpression",
             dataType: r4:Expression,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -566,7 +566,7 @@ public enum EvidenceVariableCharacteristicGroupMeasure {
         "definitionTriggerDefinition": {
             name: "definitionTriggerDefinition",
             dataType: r4:TriggerDefinition,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",

--- a/international401/resource_explanation_of_benefit.bal
+++ b/international401/resource_explanation_of_benefit.bal
@@ -948,7 +948,7 @@ public type ExplanationOfBenefitItemDetail record {|
         "diagnosisReference": {
             name: "diagnosisReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The nature of illness or problem in a coded form or as a reference to an external defined Condition.",
@@ -957,7 +957,7 @@ public type ExplanationOfBenefitItemDetail record {|
         "diagnosisCodeableConcept": {
             name: "diagnosisCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The nature of illness or problem in a coded form or as a reference to an external defined Condition.",
@@ -1632,7 +1632,7 @@ public enum ExplanationOfBenefitOutcome {
         "procedureCodeableConcept": {
             name: "procedureCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The code or reference to a Procedure resource which identifies the clinical intervention performed.",
@@ -1650,7 +1650,7 @@ public enum ExplanationOfBenefitOutcome {
         "procedureReference": {
             name: "procedureReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The code or reference to a Procedure resource which identifies the clinical intervention performed.",

--- a/international401/resource_group.bal
+++ b/international401/resource_group.bal
@@ -339,7 +339,7 @@ public enum GroupType {
         "valueCodeableConcept": {
             name: "valueCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -348,7 +348,7 @@ public enum GroupType {
         "valueBoolean": {
             name: "valueBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -384,7 +384,7 @@ public enum GroupType {
         "valueReference": {
             name: "valueReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -393,7 +393,7 @@ public enum GroupType {
         "valueRange": {
             name: "valueRange",
             dataType: r4:Range,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -429,7 +429,7 @@ public enum GroupType {
         "valueQuantity": {
             name: "valueQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",

--- a/international401/resource_group_definition.bal
+++ b/international401/resource_group_definition.bal
@@ -246,7 +246,7 @@ public type Group_Definition record {|
         "valueCodeableConcept": {
             name: "valueCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -255,7 +255,7 @@ public type Group_Definition record {|
         "valueBoolean": {
             name: "valueBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -291,7 +291,7 @@ public type Group_Definition record {|
         "valueReference": {
             name: "valueReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -300,7 +300,7 @@ public type Group_Definition record {|
         "valueRange": {
             name: "valueRange",
             dataType: r4:Range,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",
@@ -336,7 +336,7 @@ public type Group_Definition record {|
         "valueQuantity": {
             name: "valueQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the trait that holds (or does not hold - see 'exclude') for members of the group.",

--- a/international401/resource_guidance_response.bal
+++ b/international401/resource_guidance_response.bal
@@ -123,7 +123,7 @@ public const RESOURCE_NAME_GUIDANCERESPONSE = "GuidanceResponse";
         "moduleCanonical" : {
             name: "moduleCanonical",
             dataType: r4:canonical,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "GuidanceResponse.module[x]"
@@ -155,7 +155,7 @@ public const RESOURCE_NAME_GUIDANCERESPONSE = "GuidanceResponse";
         "moduleUri" : {
             name: "moduleUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "GuidanceResponse.module[x]"
@@ -195,7 +195,7 @@ public const RESOURCE_NAME_GUIDANCERESPONSE = "GuidanceResponse";
         "moduleCodeableConcept" : {
             name: "moduleCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "GuidanceResponse.module[x]"

--- a/international401/resource_immunization.bal
+++ b/international401/resource_immunization.bal
@@ -343,7 +343,7 @@ public const RESOURCE_NAME_IMMUNIZATION = "Immunization";
         "occurrenceDateTime" : {
             name: "occurrenceDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Immunization.occurrence[x]"
@@ -351,7 +351,7 @@ public const RESOURCE_NAME_IMMUNIZATION = "Immunization";
         "occurrenceString" : {
             name: "occurrenceString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Immunization.occurrence[x]"
@@ -700,7 +700,7 @@ public type ImmunizationReaction record {|
         "doseNumberString": {
             name: "doseNumberString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Nominal position in a series.",
@@ -745,7 +745,7 @@ public type ImmunizationReaction record {|
         "doseNumberPositiveInt": {
             name: "doseNumberPositiveInt",
             dataType: r4:positiveInt,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Nominal position in a series.",

--- a/international401/resource_implementation_guide.bal
+++ b/international401/resource_implementation_guide.bal
@@ -1211,7 +1211,7 @@ public type ImplementationGuideDefinitionTemplate record {|
         "nameImplementationGuideReference": {
             name: "nameImplementationGuideReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The source address for the page.",
@@ -1229,7 +1229,7 @@ public type ImplementationGuideDefinitionTemplate record {|
         "nameImplementationGuideUrl": {
             name: "nameImplementationGuideUrl",
             dataType: r4:urlType,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The source address for the page.",

--- a/international401/resource_invoice.bal
+++ b/international401/resource_invoice.bal
@@ -458,7 +458,7 @@ public type InvoiceLineItemPriceComponent record {|
         "chargeItemCodeableConcept": {
             name: "chargeItemCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The ChargeItem contains information such as the billing code, date, amount etc. If no further details are required for the lineItem, inline billing codes can be added using the CodeableConcept data type instead of the Reference.",
@@ -512,7 +512,7 @@ public type InvoiceLineItemPriceComponent record {|
         "chargeItemReference": {
             name: "chargeItemReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The ChargeItem contains information such as the billing code, date, amount etc. If no further details are required for the lineItem, inline billing codes can be added using the CodeableConcept data type instead of the Reference.",

--- a/international401/resource_medication.bal
+++ b/international401/resource_medication.bal
@@ -231,7 +231,7 @@ public enum MedicationStatus {
         "itemReference": {
             name: "itemReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual ingredient - either a substance (simple ingredient) or another medication of a medication.",
@@ -258,7 +258,7 @@ public enum MedicationStatus {
         "itemCodeableConcept": {
             name: "itemCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual ingredient - either a substance (simple ingredient) or another medication of a medication.",

--- a/international401/resource_medication_administration.bal
+++ b/international401/resource_medication_administration.bal
@@ -143,7 +143,7 @@ public const RESOURCE_NAME_MEDICATIONADMINISTRATION = "MedicationAdministration"
         "medicationReference" : {
             name: "medicationReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationAdministration.medication[x]",
@@ -210,7 +210,7 @@ public const RESOURCE_NAME_MEDICATIONADMINISTRATION = "MedicationAdministration"
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationAdministration.effective[x]"
@@ -226,7 +226,7 @@ public const RESOURCE_NAME_MEDICATIONADMINISTRATION = "MedicationAdministration"
         "medicationCodeableConcept" : {
             name: "medicationCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationAdministration.medication[x]",
@@ -243,7 +243,7 @@ public const RESOURCE_NAME_MEDICATIONADMINISTRATION = "MedicationAdministration"
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationAdministration.effective[x]"

--- a/international401/resource_medication_dispense.bal
+++ b/international401/resource_medication_dispense.bal
@@ -159,7 +159,7 @@ public const RESOURCE_NAME_MEDICATIONDISPENSE = "MedicationDispense";
         "medicationReference" : {
             name: "medicationReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationDispense.medication[x]",
@@ -272,7 +272,7 @@ public const RESOURCE_NAME_MEDICATIONDISPENSE = "MedicationDispense";
         "medicationCodeableConcept" : {
             name: "medicationCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationDispense.medication[x]",

--- a/international401/resource_medication_knowledge.bal
+++ b/international401/resource_medication_knowledge.bal
@@ -374,7 +374,7 @@ public type MedicationKnowledge record {|
         "characteristicMedicationKnowledgeQuantity": {
             name: "characteristicMedicationKnowledgeQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Specific characteristic that is relevant to the administration guideline (e.g. height, weight, gender).",
@@ -383,7 +383,7 @@ public type MedicationKnowledge record {|
         "characteristicMedicationKnowledgeCodeableConcept": {
             name: "characteristicMedicationKnowledgeCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Specific characteristic that is relevant to the administration guideline (e.g. height, weight, gender).",
@@ -676,7 +676,7 @@ public type MedicationKnowledgeMonograph record {|
         "itemReference": {
             name: "itemReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual ingredient - either a substance (simple ingredient) or another medication.",
@@ -703,7 +703,7 @@ public type MedicationKnowledgeMonograph record {|
         "itemCodeableConcept": {
             name: "itemCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual ingredient - either a substance (simple ingredient) or another medication.",

--- a/international401/resource_medication_request.bal
+++ b/international401/resource_medication_request.bal
@@ -165,7 +165,7 @@ public const RESOURCE_NAME_MEDICATIONREQUEST = "MedicationRequest";
         "medicationReference" : {
             name: "medicationReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationRequest.medication[x]",
@@ -320,7 +320,7 @@ public const RESOURCE_NAME_MEDICATIONREQUEST = "MedicationRequest";
         "medicationCodeableConcept" : {
             name: "medicationCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationRequest.medication[x]",
@@ -721,7 +721,7 @@ public enum MedicationRequestIntent {
         "allowedCodeableConcept": {
             name: "allowedCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "True if the prescriber allows a different drug to be dispensed from what was prescribed.",
@@ -757,7 +757,7 @@ public enum MedicationRequestIntent {
         "allowedBoolean": {
             name: "allowedBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "True if the prescriber allows a different drug to be dispensed from what was prescribed.",

--- a/international401/resource_medication_statement.bal
+++ b/international401/resource_medication_statement.bal
@@ -125,7 +125,7 @@ public const RESOURCE_NAME_MEDICATIONSTATEMENT = "MedicationStatement";
         "medicationReference" : {
             name: "medicationReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationStatement.medication[x]",
@@ -224,7 +224,7 @@ public const RESOURCE_NAME_MEDICATIONSTATEMENT = "MedicationStatement";
         "medicationCodeableConcept" : {
             name: "medicationCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MedicationStatement.medication[x]",

--- a/international401/resource_medicinal_product_contraindication.bal
+++ b/international401/resource_medicinal_product_contraindication.bal
@@ -210,7 +210,7 @@ public type MedicinalProductContraindication record {|
         "medicationReference": {
             name: "medicationReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication.",
@@ -255,7 +255,7 @@ public type MedicinalProductContraindication record {|
         "medicationCodeableConcept": {
             name: "medicationCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication.",

--- a/international401/resource_medicinal_product_indication.bal
+++ b/international401/resource_medicinal_product_indication.bal
@@ -230,7 +230,7 @@ public type MedicinalProductIndication record {|
         "medicationReference": {
             name: "medicationReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication.",
@@ -275,7 +275,7 @@ public type MedicinalProductIndication record {|
         "medicationCodeableConcept": {
             name: "medicationCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication.",

--- a/international401/resource_medicinal_product_interaction.bal
+++ b/international401/resource_medicinal_product_interaction.bal
@@ -209,7 +209,7 @@ public type MedicinalProductInteraction record {|
         "itemReference": {
             name: "itemReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The specific medication, food or laboratory test that interacts.",
@@ -227,7 +227,7 @@ public type MedicinalProductInteraction record {|
         "itemCodeableConcept": {
             name: "itemCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The specific medication, food or laboratory test that interacts.",

--- a/international401/resource_message_definition.bal
+++ b/international401/resource_message_definition.bal
@@ -196,7 +196,7 @@ public const RESOURCE_NAME_MESSAGEDEFINITION = "MessageDefinition";
         "eventUri" : {
             name: "eventUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MessageDefinition.event[x]",
@@ -221,7 +221,7 @@ public const RESOURCE_NAME_MESSAGEDEFINITION = "MessageDefinition";
         "eventCoding" : {
             name: "eventCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MessageDefinition.event[x]",

--- a/international401/resource_message_header.bal
+++ b/international401/resource_message_header.bal
@@ -53,7 +53,7 @@ public const RESOURCE_NAME_MESSAGEHEADER = "MessageHeader";
         "eventUri" : {
             name: "eventUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MessageHeader.event[x]",
@@ -128,7 +128,7 @@ public const RESOURCE_NAME_MESSAGEHEADER = "MessageHeader";
         "eventCoding" : {
             name: "eventCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "MessageHeader.event[x]",

--- a/international401/resource_observation_bmi.bal
+++ b/international401/resource_observation_bmi.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_BMI = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_BMI = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_bodyheight.bal
+++ b/international401/resource_observation_bodyheight.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_BODYHEIGHT = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_BODYHEIGHT = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_bodytemp.bal
+++ b/international401/resource_observation_bodytemp.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_BODYTEMP = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_BODYTEMP = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_bodyweight.bal
+++ b/international401/resource_observation_bodyweight.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_BODYWEIGHT = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_BODYWEIGHT = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_bp.bal
+++ b/international401/resource_observation_bp.bal
@@ -228,7 +228,7 @@ public const RESOURCE_NAME_OBSERVATION_BP = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -294,7 +294,7 @@ public const RESOURCE_NAME_OBSERVATION_BP = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_headcircum.bal
+++ b/international401/resource_observation_headcircum.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_HEADCIRCUM = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_HEADCIRCUM = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_heartrate.bal
+++ b/international401/resource_observation_heartrate.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_HEARTRATE = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_HEARTRATE = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_oxygensat.bal
+++ b/international401/resource_observation_oxygensat.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_OXYGENSAT = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_OXYGENSAT = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_resprate.bal
+++ b/international401/resource_observation_resprate.bal
@@ -219,7 +219,7 @@ public const RESOURCE_NAME_OBSERVATION_RESPRATE = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_RESPRATE = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_vitalsigns.bal
+++ b/international401/resource_observation_vitalsigns.bal
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_VITALSIGNS = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -359,7 +359,7 @@ public const RESOURCE_NAME_OBSERVATION_VITALSIGNS = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_observation_vitalspanel.bal
+++ b/international401/resource_observation_vitalspanel.bal
@@ -285,7 +285,7 @@ public const RESOURCE_NAME_OBSERVATION_VITALSPANEL = "Observation";
         "effectivePeriod" : {
             name: "effectivePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"
@@ -359,7 +359,7 @@ public const RESOURCE_NAME_OBSERVATION_VITALSPANEL = "Observation";
         "effectiveDateTime" : {
             name: "effectiveDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "Observation.effective[x]"

--- a/international401/resource_pico_element_profile.bal
+++ b/international401/resource_pico_element_profile.bal
@@ -464,7 +464,7 @@ public enum PICO_Element_ProfileCharacteristicGroupMeasure {
         "definitionCodeableConcept": {
             name: "definitionCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -491,7 +491,7 @@ public enum PICO_Element_ProfileCharacteristicGroupMeasure {
         "definitionCanonical": {
             name: "definitionCanonical",
             dataType: r4:canonical,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -509,7 +509,7 @@ public enum PICO_Element_ProfileCharacteristicGroupMeasure {
         "definitionDataRequirement": {
             name: "definitionDataRequirement",
             dataType: r4:DataRequirement,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -545,7 +545,7 @@ public enum PICO_Element_ProfileCharacteristicGroupMeasure {
         "definitionReference": {
             name: "definitionReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -572,7 +572,7 @@ public enum PICO_Element_ProfileCharacteristicGroupMeasure {
         "definitionExpression": {
             name: "definitionExpression",
             dataType: r4:Expression,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -581,7 +581,7 @@ public enum PICO_Element_ProfileCharacteristicGroupMeasure {
         "definitionTriggerDefinition": {
             name: "definitionTriggerDefinition",
             dataType: r4:TriggerDefinition,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",

--- a/international401/resource_profile_for_catalog.bal
+++ b/international401/resource_profile_for_catalog.bal
@@ -537,7 +537,7 @@ public type Profile_for_CatalogAttester record {|
         "targetIdentifier": {
             name: "targetIdentifier",
             dataType: r4:Identifier,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The target composition/document of this relationship.",
@@ -573,7 +573,7 @@ public type Profile_for_CatalogAttester record {|
         "targetReference": {
             name: "targetReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The target composition/document of this relationship.",

--- a/international401/resource_questionnaire.bal
+++ b/international401/resource_questionnaire.bal
@@ -405,7 +405,7 @@ public enum QuestionnaireItemType {
         "valueQuestionnaireCoding": {
             name: "valueQuestionnaireCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -441,7 +441,7 @@ public enum QuestionnaireItemType {
         "valueQuestionnaireInteger": {
             name: "valueQuestionnaireInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -450,7 +450,7 @@ public enum QuestionnaireItemType {
         "valueQuestionnaireString": {
             name: "valueQuestionnaireString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -459,7 +459,7 @@ public enum QuestionnaireItemType {
         "valueQuestionnaireDate": {
             name: "valueQuestionnaireDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -468,7 +468,7 @@ public enum QuestionnaireItemType {
         "valueQuestionnaireTime": {
             name: "valueQuestionnaireTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -477,7 +477,7 @@ public enum QuestionnaireItemType {
         "valueQuestionnaireReference": {
             name: "valueQuestionnaireReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A potential answer that's allowed as the answer to this question.",
@@ -782,7 +782,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireCoding": {
             name: "valueQuestionnaireCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -800,7 +800,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireUri": {
             name: "valueQuestionnaireUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -809,7 +809,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireBoolean": {
             name: "valueQuestionnaireBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -818,7 +818,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireAttachment": {
             name: "valueQuestionnaireAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -827,7 +827,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireReference": {
             name: "valueQuestionnaireReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -836,7 +836,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireDecimal": {
             name: "valueQuestionnaireDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -845,7 +845,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireDateTime": {
             name: "valueQuestionnaireDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -854,7 +854,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireQuantity": {
             name: "valueQuestionnaireQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -872,7 +872,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireInteger": {
             name: "valueQuestionnaireInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -881,7 +881,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireString": {
             name: "valueQuestionnaireString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -890,7 +890,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireDate": {
             name: "valueQuestionnaireDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -899,7 +899,7 @@ public enum QuestionnaireItemEnableWhenOperator {
         "valueQuestionnaireTime": {
             name: "valueQuestionnaireTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The actual value to for an initial answer.",
@@ -955,7 +955,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireReference": {
             name: "answerQuestionnaireReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -964,7 +964,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireDate": {
             name: "answerQuestionnaireDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -991,7 +991,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireDecimal": {
             name: "answerQuestionnaireDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1009,7 +1009,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireTime": {
             name: "answerQuestionnaireTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1018,7 +1018,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireString": {
             name: "answerQuestionnaireString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1027,7 +1027,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireCoding": {
             name: "answerQuestionnaireCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1036,7 +1036,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireInteger": {
             name: "answerQuestionnaireInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1045,7 +1045,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireQuantity": {
             name: "answerQuestionnaireQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1063,7 +1063,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireDateTime": {
             name: "answerQuestionnaireDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",
@@ -1072,7 +1072,7 @@ public type QuestionnaireItemInitial record {|
         "answerQuestionnaireBoolean": {
             name: "answerQuestionnaireBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "A value that the referenced question is tested using the specified operator in order for the item to be enabled.",

--- a/international401/resource_research_element_definition.bal
+++ b/international401/resource_research_element_definition.bal
@@ -537,7 +537,7 @@ public enum ResearchElementDefinitionCharacteristicParticipantEffectiveGroupMeas
         "definitionCodeableConcept": {
             name: "definitionCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the research element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -573,7 +573,7 @@ public enum ResearchElementDefinitionCharacteristicParticipantEffectiveGroupMeas
         "definitionCanonical": {
             name: "definitionCanonical",
             dataType: r4:canonical,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the research element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -600,7 +600,7 @@ public enum ResearchElementDefinitionCharacteristicParticipantEffectiveGroupMeas
         "definitionDataRequirement": {
             name: "definitionDataRequirement",
             dataType: r4:DataRequirement,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the research element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",
@@ -672,7 +672,7 @@ public enum ResearchElementDefinitionCharacteristicParticipantEffectiveGroupMeas
         "definitionExpression": {
             name: "definitionExpression",
             dataType: r4:Expression,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Define members of the research element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).",

--- a/international401/resource_specimen_definition.bal
+++ b/international401/resource_specimen_definition.bal
@@ -440,7 +440,7 @@ public type SpecimenDefinitionTypeTestedHandling record {|
         "additiveSpecimenDefinitionReference": {
             name: "additiveSpecimenDefinitionReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Substance introduced in the kind of container to preserve, maintain or enhance the specimen. Examples: Formalin, Citrate, EDTA.",
@@ -467,7 +467,7 @@ public type SpecimenDefinitionTypeTestedHandling record {|
         "additiveSpecimenDefinitionCodeableConcept": {
             name: "additiveSpecimenDefinitionCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Substance introduced in the kind of container to preserve, maintain or enhance the specimen. Examples: Formalin, Citrate, EDTA.",

--- a/international401/resource_structure_map.bal
+++ b/international401/resource_structure_map.bal
@@ -458,7 +458,7 @@ public enum StructureMapStatus {
         "valueStructureMapDecimal": {
             name: "valueStructureMapDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Parameter value - variable or literal.",
@@ -485,7 +485,7 @@ public enum StructureMapStatus {
         "valueStructureMapString": {
             name: "valueStructureMapString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Parameter value - variable or literal.",
@@ -503,7 +503,7 @@ public enum StructureMapStatus {
         "valueStructureMapBoolean": {
             name: "valueStructureMapBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Parameter value - variable or literal.",
@@ -512,7 +512,7 @@ public enum StructureMapStatus {
         "valueStructureMapInteger": {
             name: "valueStructureMapInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Parameter value - variable or literal.",
@@ -521,7 +521,7 @@ public enum StructureMapStatus {
         "valueStructureMapId": {
             name: "valueStructureMapId",
             dataType: r4:id,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Parameter value - variable or literal.",

--- a/international401/resource_substance.bal
+++ b/international401/resource_substance.bal
@@ -231,7 +231,7 @@ public type Substance record {|
         "substanceCodeableConcept": {
             name: "substanceCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Another substance that is a component of this substance.",
@@ -258,7 +258,7 @@ public type Substance record {|
         "substanceReference": {
             name: "substanceReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "Another substance that is a component of this substance.",

--- a/international401/resource_supply_request.bal
+++ b/international401/resource_supply_request.bal
@@ -108,7 +108,7 @@ public const RESOURCE_NAME_SUPPLYREQUEST = "SupplyRequest";
         "itemCodeableConcept" : {
             name: "itemCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "SupplyRequest.item[x]",
@@ -207,7 +207,7 @@ public const RESOURCE_NAME_SUPPLYREQUEST = "SupplyRequest";
         "itemReference" : {
             name: "itemReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             path: "SupplyRequest.item[x]",

--- a/international401/resource_task.bal
+++ b/international401/resource_task.bal
@@ -511,7 +511,7 @@ public enum TaskPriority {
         "valueTime": {
             name: "valueTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -520,7 +520,7 @@ public enum TaskPriority {
         "valueTriggerDefinition": {
             name: "valueTriggerDefinition",
             dataType: r4:TriggerDefinition,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -529,7 +529,7 @@ public enum TaskPriority {
         "valueMoney": {
             name: "valueMoney",
             dataType: r4:Money,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -538,7 +538,7 @@ public enum TaskPriority {
         "valueSignature": {
             name: "valueSignature",
             dataType: r4:Signature,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -565,7 +565,7 @@ public enum TaskPriority {
         "valueUuid": {
             name: "valueUuid",
             dataType: r4:uuid,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -574,7 +574,7 @@ public enum TaskPriority {
         "valueRatio": {
             name: "valueRatio",
             dataType: r4:Ratio,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -583,7 +583,7 @@ public enum TaskPriority {
         "valueParameterDefinition": {
             name: "valueParameterDefinition",
             dataType: r4:ParameterDefinition,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -601,7 +601,7 @@ public enum TaskPriority {
         "valueInteger": {
             name: "valueInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -610,7 +610,7 @@ public enum TaskPriority {
         "valueUnsignedInt": {
             name: "valueUnsignedInt",
             dataType: r4:unsignedInt,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -619,7 +619,7 @@ public enum TaskPriority {
         "valueQuantity": {
             name: "valueQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -628,7 +628,7 @@ public enum TaskPriority {
         "valueCanonical": {
             name: "valueCanonical",
             dataType: r4:canonical,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -637,7 +637,7 @@ public enum TaskPriority {
         "valueCount": {
             name: "valueCount",
             dataType: r4:Count,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -646,7 +646,7 @@ public enum TaskPriority {
         "valueId": {
             name: "valueId",
             dataType: r4:id,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -655,7 +655,7 @@ public enum TaskPriority {
         "valueCode": {
             name: "valueCode",
             dataType: r4:code,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -664,7 +664,7 @@ public enum TaskPriority {
         "valueAddress": {
             name: "valueAddress",
             dataType: r4:Address,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -673,7 +673,7 @@ public enum TaskPriority {
         "valueContactPoint": {
             name: "valueContactPoint",
             dataType: r4:ContactPoint,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -682,7 +682,7 @@ public enum TaskPriority {
         "valuePeriod": {
             name: "valuePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -691,7 +691,7 @@ public enum TaskPriority {
         "valueSampledData": {
             name: "valueSampledData",
             dataType: r4:SampledData,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -700,7 +700,7 @@ public enum TaskPriority {
         "valueTiming": {
             name: "valueTiming",
             dataType: r4:Timing,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -709,7 +709,7 @@ public enum TaskPriority {
         "valueInstant": {
             name: "valueInstant",
             dataType: r4:instant,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -718,7 +718,7 @@ public enum TaskPriority {
         "valueAge": {
             name: "valueAge",
             dataType: r4:Age,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -727,7 +727,7 @@ public enum TaskPriority {
         "valueDosage": {
             name: "valueDosage",
             dataType: r4:Dosage,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -736,7 +736,7 @@ public enum TaskPriority {
         "valueBase64Binary": {
             name: "valueBase64Binary",
             dataType: r4:base64Binary,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -745,7 +745,7 @@ public enum TaskPriority {
         "valueBoolean": {
             name: "valueBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -754,7 +754,7 @@ public enum TaskPriority {
         "valueCoding": {
             name: "valueCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -772,7 +772,7 @@ public enum TaskPriority {
         "valueIdentifier": {
             name: "valueIdentifier",
             dataType: r4:Identifier,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -781,7 +781,7 @@ public enum TaskPriority {
         "valueExpression": {
             name: "valueExpression",
             dataType: r4:Expression,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -790,7 +790,7 @@ public enum TaskPriority {
         "valueReference": {
             name: "valueReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -799,7 +799,7 @@ public enum TaskPriority {
         "valueRange": {
             name: "valueRange",
             dataType: r4:Range,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -808,7 +808,7 @@ public enum TaskPriority {
         "valueUri": {
             name: "valueUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -817,7 +817,7 @@ public enum TaskPriority {
         "valueDistance": {
             name: "valueDistance",
             dataType: r4:Distance,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -826,7 +826,7 @@ public enum TaskPriority {
         "valueUrl": {
             name: "valueUrl",
             dataType: r4:urlType,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -835,7 +835,7 @@ public enum TaskPriority {
         "valueContactDetail": {
             name: "valueContactDetail",
             dataType: r4:ContactDetail,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -844,7 +844,7 @@ public enum TaskPriority {
         "valueMeta": {
             name: "valueMeta",
             dataType: r4:Meta,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -853,7 +853,7 @@ public enum TaskPriority {
         "valueCodeableConcept": {
             name: "valueCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -862,7 +862,7 @@ public enum TaskPriority {
         "valueMarkdown": {
             name: "valueMarkdown",
             dataType: r4:markdown,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -871,7 +871,7 @@ public enum TaskPriority {
         "valueAttachment": {
             name: "valueAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -880,7 +880,7 @@ public enum TaskPriority {
         "valueUsageContext": {
             name: "valueUsageContext",
             dataType: r4:UsageContext,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -889,7 +889,7 @@ public enum TaskPriority {
         "valueDateTime": {
             name: "valueDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -898,7 +898,7 @@ public enum TaskPriority {
         "valueHumanName": {
             name: "valueHumanName",
             dataType: r4:HumanName,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -907,7 +907,7 @@ public enum TaskPriority {
         "valueRelatedArtifact": {
             name: "valueRelatedArtifact",
             dataType: r4:RelatedArtifact,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -916,7 +916,7 @@ public enum TaskPriority {
         "valueDecimal": {
             name: "valueDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -925,7 +925,7 @@ public enum TaskPriority {
         "valueDate": {
             name: "valueDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -934,7 +934,7 @@ public enum TaskPriority {
         "valueOid": {
             name: "valueOid",
             dataType: r4:oid,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -943,7 +943,7 @@ public enum TaskPriority {
         "valueContributor": {
             name: "valueContributor",
             dataType: r4:Contributor,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -952,7 +952,7 @@ public enum TaskPriority {
         "valueString": {
             name: "valueString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -961,7 +961,7 @@ public enum TaskPriority {
         "valuePositiveInt": {
             name: "valuePositiveInt",
             dataType: r4:positiveInt,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -970,7 +970,7 @@ public enum TaskPriority {
         "valueDuration": {
             name: "valueDuration",
             dataType: r4:Duration,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -979,7 +979,7 @@ public enum TaskPriority {
         "valueDataRequirement": {
             name: "valueDataRequirement",
             dataType: r4:DataRequirement,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -988,7 +988,7 @@ public enum TaskPriority {
         "valueAnnotation": {
             name: "valueAnnotation",
             dataType: r4:Annotation,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the input parameter as a basic type.",
@@ -1205,7 +1205,7 @@ public type TaskRestriction record {|
         "valueTime": {
             name: "valueTime",
             dataType: r4:time,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1214,7 +1214,7 @@ public type TaskRestriction record {|
         "valueTriggerDefinition": {
             name: "valueTriggerDefinition",
             dataType: r4:TriggerDefinition,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1223,7 +1223,7 @@ public type TaskRestriction record {|
         "valueMoney": {
             name: "valueMoney",
             dataType: r4:Money,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1232,7 +1232,7 @@ public type TaskRestriction record {|
         "valueSignature": {
             name: "valueSignature",
             dataType: r4:Signature,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1259,7 +1259,7 @@ public type TaskRestriction record {|
         "valueUuid": {
             name: "valueUuid",
             dataType: r4:uuid,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1268,7 +1268,7 @@ public type TaskRestriction record {|
         "valueRatio": {
             name: "valueRatio",
             dataType: r4:Ratio,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1277,7 +1277,7 @@ public type TaskRestriction record {|
         "valueParameterDefinition": {
             name: "valueParameterDefinition",
             dataType: r4:ParameterDefinition,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1295,7 +1295,7 @@ public type TaskRestriction record {|
         "valueInteger": {
             name: "valueInteger",
             dataType: r4:integer,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1304,7 +1304,7 @@ public type TaskRestriction record {|
         "valueUnsignedInt": {
             name: "valueUnsignedInt",
             dataType: r4:unsignedInt,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1313,7 +1313,7 @@ public type TaskRestriction record {|
         "valueQuantity": {
             name: "valueQuantity",
             dataType: r4:Quantity,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1322,7 +1322,7 @@ public type TaskRestriction record {|
         "valueCanonical": {
             name: "valueCanonical",
             dataType: r4:canonical,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1331,7 +1331,7 @@ public type TaskRestriction record {|
         "valueCount": {
             name: "valueCount",
             dataType: r4:Count,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1340,7 +1340,7 @@ public type TaskRestriction record {|
         "valueId": {
             name: "valueId",
             dataType: r4:id,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1349,7 +1349,7 @@ public type TaskRestriction record {|
         "valueCode": {
             name: "valueCode",
             dataType: r4:code,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1358,7 +1358,7 @@ public type TaskRestriction record {|
         "valueAddress": {
             name: "valueAddress",
             dataType: r4:Address,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1367,7 +1367,7 @@ public type TaskRestriction record {|
         "valueContactPoint": {
             name: "valueContactPoint",
             dataType: r4:ContactPoint,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1376,7 +1376,7 @@ public type TaskRestriction record {|
         "valuePeriod": {
             name: "valuePeriod",
             dataType: r4:Period,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1385,7 +1385,7 @@ public type TaskRestriction record {|
         "valueSampledData": {
             name: "valueSampledData",
             dataType: r4:SampledData,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1394,7 +1394,7 @@ public type TaskRestriction record {|
         "valueTiming": {
             name: "valueTiming",
             dataType: r4:Timing,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1403,7 +1403,7 @@ public type TaskRestriction record {|
         "valueInstant": {
             name: "valueInstant",
             dataType: r4:instant,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1412,7 +1412,7 @@ public type TaskRestriction record {|
         "valueAge": {
             name: "valueAge",
             dataType: r4:Age,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1421,7 +1421,7 @@ public type TaskRestriction record {|
         "valueDosage": {
             name: "valueDosage",
             dataType: r4:Dosage,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1430,7 +1430,7 @@ public type TaskRestriction record {|
         "valueBase64Binary": {
             name: "valueBase64Binary",
             dataType: r4:base64Binary,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1439,7 +1439,7 @@ public type TaskRestriction record {|
         "valueBoolean": {
             name: "valueBoolean",
             dataType: boolean,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1448,7 +1448,7 @@ public type TaskRestriction record {|
         "valueCoding": {
             name: "valueCoding",
             dataType: r4:Coding,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1466,7 +1466,7 @@ public type TaskRestriction record {|
         "valueIdentifier": {
             name: "valueIdentifier",
             dataType: r4:Identifier,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1475,7 +1475,7 @@ public type TaskRestriction record {|
         "valueExpression": {
             name: "valueExpression",
             dataType: r4:Expression,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1484,7 +1484,7 @@ public type TaskRestriction record {|
         "valueReference": {
             name: "valueReference",
             dataType: r4:Reference,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1493,7 +1493,7 @@ public type TaskRestriction record {|
         "valueRange": {
             name: "valueRange",
             dataType: r4:Range,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1502,7 +1502,7 @@ public type TaskRestriction record {|
         "valueUri": {
             name: "valueUri",
             dataType: r4:uri,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1511,7 +1511,7 @@ public type TaskRestriction record {|
         "valueDistance": {
             name: "valueDistance",
             dataType: r4:Distance,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1520,7 +1520,7 @@ public type TaskRestriction record {|
         "valueUrl": {
             name: "valueUrl",
             dataType: r4:urlType,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1529,7 +1529,7 @@ public type TaskRestriction record {|
         "valueContactDetail": {
             name: "valueContactDetail",
             dataType: r4:ContactDetail,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1538,7 +1538,7 @@ public type TaskRestriction record {|
         "valueMeta": {
             name: "valueMeta",
             dataType: r4:Meta,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1547,7 +1547,7 @@ public type TaskRestriction record {|
         "valueCodeableConcept": {
             name: "valueCodeableConcept",
             dataType: r4:CodeableConcept,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1556,7 +1556,7 @@ public type TaskRestriction record {|
         "valueMarkdown": {
             name: "valueMarkdown",
             dataType: r4:markdown,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1565,7 +1565,7 @@ public type TaskRestriction record {|
         "valueAttachment": {
             name: "valueAttachment",
             dataType: r4:Attachment,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1574,7 +1574,7 @@ public type TaskRestriction record {|
         "valueUsageContext": {
             name: "valueUsageContext",
             dataType: r4:UsageContext,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1583,7 +1583,7 @@ public type TaskRestriction record {|
         "valueDateTime": {
             name: "valueDateTime",
             dataType: r4:dateTime,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1592,7 +1592,7 @@ public type TaskRestriction record {|
         "valueHumanName": {
             name: "valueHumanName",
             dataType: r4:HumanName,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1601,7 +1601,7 @@ public type TaskRestriction record {|
         "valueRelatedArtifact": {
             name: "valueRelatedArtifact",
             dataType: r4:RelatedArtifact,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1610,7 +1610,7 @@ public type TaskRestriction record {|
         "valueDecimal": {
             name: "valueDecimal",
             dataType: decimal,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1619,7 +1619,7 @@ public type TaskRestriction record {|
         "valueDate": {
             name: "valueDate",
             dataType: r4:date,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1628,7 +1628,7 @@ public type TaskRestriction record {|
         "valueOid": {
             name: "valueOid",
             dataType: r4:oid,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1637,7 +1637,7 @@ public type TaskRestriction record {|
         "valueContributor": {
             name: "valueContributor",
             dataType: r4:Contributor,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1646,7 +1646,7 @@ public type TaskRestriction record {|
         "valueString": {
             name: "valueString",
             dataType: string,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1655,7 +1655,7 @@ public type TaskRestriction record {|
         "valuePositiveInt": {
             name: "valuePositiveInt",
             dataType: r4:positiveInt,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1664,7 +1664,7 @@ public type TaskRestriction record {|
         "valueDuration": {
             name: "valueDuration",
             dataType: r4:Duration,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1673,7 +1673,7 @@ public type TaskRestriction record {|
         "valueDataRequirement": {
             name: "valueDataRequirement",
             dataType: r4:DataRequirement,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",
@@ -1682,7 +1682,7 @@ public type TaskRestriction record {|
         "valueAnnotation": {
             name: "valueAnnotation",
             dataType: r4:Annotation,
-            min: 1,
+            min: 0,
             max: 1,
             isArray: false,
             description: "The value of the Output parameter as a basic type.",


### PR DESCRIPTION
## Purpose
Currently, when a resource parameter has a required cardinality `(1..1)` and supports multiple datatypes (value[x]), the health tool incorrectly treats all datatypes as mandatory. However, according to FHIR specifications, such fields are meant to be mandatory in exactly one of the allowed datatypes, not all of them.

Example: See [item[x]](https://hl7.org/fhir/R4/supplyrequest.html) in the SupplyRequest resource from the international401 package.

## Goals
To correctly reflect the FHIR definition, update the health tool to treat all multi-datatype fields as optional, since expressing "required in one of the options" cannot be directly modeled with current language constraints.

## Approach
This issue was identified during testing of the FHIR R5 implementation for the health tool. The solution is to override the cardinality of multi-datatype fields to `0..1`, marking all as optional regardless of their original FHIR-defined cardinality.

## User stories
N/A

## Release note
Corrected interpretation of multi-datatype fields by marking them as optional when their exact cardinality cannot be represented.

## Documentation
N/A — no documentation impact as this affects internal code generation logic.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Manually verified.
Note: When multi-datatype array fields are made optional, users must explicitly cast them to the correct datatype. This behavior should ideally be handled at the Ballerina language level.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK: 21
Ballerina: 2201.12.3
OS: Windows 11
 
## Learning
N/A