### PR TITLE
Add support for default listener for fhirr4 service

### DIFF
--- a/fhirr4/ballerina/pom.xml
+++ b/fhirr4/ballerina/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>2.0.4</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/ballerina/src/main/resources/fhirservice/listener.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/listener.bal
@@ -24,8 +24,15 @@ public isolated class Listener {
     private final r4:ResourceAPIConfig config;
     private http:Service httpService = isolated service object {};
 
-    public isolated function init(int port, r4:ResourceAPIConfig config) returns error? {
-        self.ls = check new (port);
+    public isolated function init(int? port = (), r4:ResourceAPIConfig config = {operations: [], authzConfig: (), profiles: [], defaultProfile: (), searchParameters: [], serverConfig: (), resourceType: ""}) returns error? {
+        if config.resourceType == "" {
+            return error("Resource type cannot be empty in the API config. Please provide a valid FHIR resource type.");
+        }
+        if port is () {
+            self.ls = check http:getDefaultListener();
+        } else {
+            self.ls = check new (port);
+        }
         self.config = config;
     }
 

--- a/fhirr4/ballerina/src/main/resources/fhirservice/tests/fhir_service_test.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/tests/fhir_service_test.bal
@@ -343,6 +343,17 @@ function testMetadata() returns error? {
     test:assertTrue(response is international401:CapabilityStatement);
 }
 
+@test:Config { groups: ["FhirService"] }
+function testInvalidApiConfig() returns error? {
+    r4:ResourceAPIConfig invalidApiConfig = {operations: [], authzConfig: (), profiles: [], defaultProfile: (), 
+        searchParameters: [], serverConfig: (), resourceType: ""};
+    Listener|error fhirListener = new (config = invalidApiConfig);
+    test:assertTrue(fhirListener is error, "Expected an error when creating a listener with invalid API config");
+    if fhirListener is error {
+        test:assertEquals(fhirListener.message(), "Resource type cannot be empty in the API config. Please provide a valid FHIR resource type.");
+    } 
+}
+
 @test:AfterGroups { value:["FhirService"] }
 function stopService() returns error? {
     check fhirListener.gracefulStop();

--- a/fhirr4/compiler-plugin/pom.xml
+++ b/fhirr4/compiler-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>2.0.4</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/native/pom.xml
+++ b/fhirr4/native/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>fhirr4</artifactId>
         <groupId>io.ballerinax</groupId>
-        <version>2.0.4</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fhirr4/pom.xml
+++ b/fhirr4/pom.xml
@@ -25,7 +25,7 @@
     <groupId>io.ballerinax</groupId>
     <artifactId>fhirr4</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.4</version>
+    <version>2.1.0</version>
     <modules>
         <module>compiler-plugin</module>
         <module>native</module>


### PR DESCRIPTION
## Purpose
> $Subject. This will enable the monolithic deployment where all the FHIR APIs will serve on the default http listener port.