### PR TITLE
Fix InherentTypeViolation for Empty Search Parameter Values in FHIRPreprocessor

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
@@ -609,8 +609,13 @@ public isolated class FHIRPreprocessor {
 
             // Decode search parameter key and seperate name and modifier
             // Refer: http://hl7.org/fhir/search.html#modifiers
+            string[]? paramValues = requestQueryParams[originalParamName];
+            if paramValues is () || paramValues.length() == 0 {
+                return r4:createFHIRError(string `Search parameter ${originalParamName} has no value`, r4:ERROR, r4:PROCESSING,
+                        httpStatusCode = http:STATUS_BAD_REQUEST);
+            }
             r4:RequestQueryParameter queryParam =
-                            check r4:decodeSearchParameterKey(originalParamName, requestQueryParams.get(originalParamName));
+                            check r4:decodeSearchParameterKey(originalParamName, paramValues);
             r4:RequestSearchParameter[] processResult;
             if searchParamDefinitions.hasKey(queryParam.name) {
                 // Processing search parameters bound to resource


### PR DESCRIPTION
## Purpose
- To fix an `InherentTypeViolation` error that occurs when processing search parameters with missing or empty values in the `FHIRPreprocessor:processSearchParameters` function. The root cause was passing () (nil) instead of a `string[]` to the `decodeSearchParameterKey` function, which expects a non-nil array of strings for the values field.
- Prevents server errors and improves robustness when clients send search parameters without values.


<img width="1665" height="937" alt="image" src="https://github.com/user-attachments/assets/d5cc4e60-10da-406e-a87b-917ba6bbe739" />
