### PR TITLE
Add FHIR services management and extend OperationConfig with additionalProperties

### DIFF
--- a/r4/Dependencies.toml
+++ b/r4/Dependencies.toml
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/r4/core.bal
+++ b/r4/core.bal
@@ -534,3 +534,14 @@ public type PaginationContext record {|
     readonly int page;
     readonly int pageSize;
 |};
+
+# Record to hold FHIR service information.
+# 
+# + name - The name of the service
+# + serviceUrl - The service URL
+# + status - Service status (active, inactive)
+public type FHIRServiceInfo record {|
+    string name;
+    string serviceUrl;
+    string status = "active";
+|};

--- a/r4/fhir_api_config.bal
+++ b/r4/fhir_api_config.bal
@@ -97,6 +97,7 @@ public type OperationParamConfig record {|
 # + preProcessor - Override this operation pre-processing function. If the integration  developer wants to take control of pre-processing the operation.  
 # + postProcessor - Override this operation post-processing function. If the integration  developer wants to take control of post-processing the operation.
 # + information - Meta information about the operation (no processed, just for information)
+# + additionalProperties - Additional properties that can be used to extend the operation configuration
 public type OperationConfig record {|
     readonly string name;
     readonly boolean active;
@@ -104,6 +105,7 @@ public type OperationConfig record {|
     readonly & OperationPreProcessor preProcessor?;
     readonly & OperationPostProcessor postProcessor?;
     readonly Information information?;
+    readonly json additionalProperties?;
 |};
 
 # Information about a rest feature.

--- a/r4/fhir_registry.bal
+++ b/r4/fhir_registry.bal
@@ -86,6 +86,9 @@ public isolated class FHIRRegistry {
     // Operations map (key: resource type)
     private map<OperationCollection> operationsMap = {};
 
+    // FHIR services map (key: resource type)
+    private FHIRServicesCollection fhirServicesMap = {};
+
     public function init() {
     }
 
@@ -293,6 +296,53 @@ public isolated class FHIRRegistry {
             }
         }
     }
+
+    # Add a FHIR service to the registry
+    #
+    # + resourceType - The resource type
+    # + serviceInfo - The FHIR service information
+    public isolated function registerFHIRService(string resourceType, FHIRServiceInfo serviceInfo) {
+        lock {
+            if !self.fhirServicesMap.hasKey(resourceType) {
+                self.fhirServicesMap[resourceType] = serviceInfo.clone();
+            }
+        }
+    }
+
+    # Get a FHIR service from the registry by resource type
+    #
+    # + resourceType - The resource type
+    # + return - The FHIR service information if found, otherwise ()
+    public isolated function getFHIRService(string resourceType) returns FHIRServiceInfo? {
+        lock {
+            if self.fhirServicesMap.hasKey(resourceType) {
+                return self.fhirServicesMap.get(resourceType).clone();
+            }
+        }
+        return ();
+    }
+
+    # Get all FHIR services in the registry
+    # + return - A map of FHIR services where the key is the resource type
+    public isolated function getAllRegisteredFHIRServices() returns FHIRServicesCollection {
+        lock {
+            return self.fhirServicesMap.cloneReadOnly();
+        }
+    }
+
+    # Remove a FHIR service from the registry
+    #
+    # + resourceType - The resource type
+    # + return - True if the service was removed, false if not found
+    public isolated function removeFHIRService(string resourceType) returns boolean {
+        lock {
+            if self.fhirServicesMap.hasKey(resourceType) {
+                _ = self.fhirServicesMap.remove(resourceType);
+                return true;
+            }
+        }
+        return false;
+    }
 }
 
 # Search parameter map (key: parameter name)
@@ -300,3 +350,6 @@ public type SearchParamCollection map<FHIRSearchParameterDefinition>;
 
 # Operation map (key: operation name)
 public type OperationCollection map<FHIROperationDefinition>;
+
+# FHIR services map (key: service name)
+public type FHIRServicesCollection map<FHIRServiceInfo>;


### PR DESCRIPTION
## Purpose
This PR introduces FHIR services management capabilities to the `FHIRRegistry` and extends the `OperationConfig` type with additional configuration properties.

## Goals
- Introduce service map to the FHIR registry to track the services with the resource type
- Add additional property to the `OperationConfig` in `ResourceApiConfig` to configure additional properties which relevant to the operations

## Approach
- FHIR Services Management
  - Added private field: `fhirServicesMap` to store FHIR service information by resource type
  - New methods added:
    - `addResourceFHIRService()` - Add a FHIR service to the registry
    - `getResourceFHIRService()` - Retrieve a FHIR service by resource type
    - `removeResourceFHIRService()` - Remove a FHIR service from the registry
  - New type definition: `FHIRServicesCollection` for type safety
- Enhanced Operation Configuration
  - Extended `OperationConfig` with optional `additionalProperties` field of type json
  - Enables flexible extension of operation configurations without breaking existing APIs

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? no

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- JDK: openjdk 21.0.6
- Ballerina: 2201.12.3
- OS: Windows 11 Pro
 
## Learning
N/A