### PR TITLE
Add union operator for ENUM types

### DIFF
--- a/r4/datatype_address.bal
+++ b/r4/datatype_address.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -135,8 +136,15 @@ public type Address record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    AddressUse use?;
-    AddressType 'type?;
+    @constraint:String {
+        pattern: re`home|work|temp|old|billing`
+    }
+    string | AddressUse use?;
+
+    @constraint:String {
+        pattern: re`postal|physical|both`
+    }
+    string | AddressType 'type?;
     string text?;
     string[] line?;
     string city?;

--- a/r4/datatype_contact_point.bal
+++ b/r4/datatype_contact_point.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -80,9 +81,16 @@ public type ContactPoint record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    ContactPointSystem system?;
+    @constraint:String {
+        pattern: re`phone|fax|email|pager|url|sms|other`
+    }
+    string | ContactPointSystem system?;
     string value?;
-    ContactPointUse use?;
+
+    @constraint:String {
+        pattern: re`home|work|temp|old|mobile`
+    }
+    string | ContactPointUse use?;
     positiveInt rank?;
     Period period?;
 |};

--- a/r4/datatype_contributer.bal
+++ b/r4/datatype_contributer.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -63,7 +64,10 @@ public type Contributer record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    ContributerType 'type;
+    @constraint:String {
+        pattern: re`author|editor|reviewer|endorser`
+    }
+    string | ContributerType 'type;
     string name;
     ContactDetail[] contact?;
 |};

--- a/r4/datatype_contributor.bal
+++ b/r4/datatype_contributor.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -63,7 +64,10 @@ public type Contributor record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    ContributorType 'type;
+    @constraint:String {
+        pattern: re`author|editor|reviewer|endorser`
+    }
+    string | ContributorType 'type;
     string name;
     ContactDetail[] contact?;
 |};

--- a/r4/datatype_element_binding.bal
+++ b/r4/datatype_element_binding.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -63,7 +64,10 @@ public type ElementBinding record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    StrengthCode strength;
+    @constraint:String{
+        pattern: re`required|extensible|preferred|example`
+    }
+    string | StrengthCode strength;
     string description?;
     canonical valueSet?;
 |};

--- a/r4/datatype_element_discriminator.bal
+++ b/r4/datatype_element_discriminator.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -54,6 +55,9 @@ public type ElementDiscriminator record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
+    @constraint:String {
+        pattern: re`value|exists|pattern|'type|profile`
+    }
     ElementDiscriminatorType 'type;
     string path;
 |};

--- a/r4/datatype_element_repeat.bal
+++ b/r4/datatype_element_repeat.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -199,12 +200,18 @@ public type ElementRepeat record {
     positiveInt countMax?;
     decimal duration?;
     decimal durationMax?;
-    Timecode durationUnit?;
+    @constraint:String {
+        pattern: re`s|min|h|d|wk|mo|a`
+    }
+    string | Timecode durationUnit?;
     positiveInt frequency?;
     positiveInt frequencyMax?;
     decimal period?;
     decimal periodMax?;
-    Timecode periodUnit?;
+    @constraint:String {
+        pattern: re`s|min|h|d|wk|mo|a`
+    }
+    string | Timecode periodUnit?;
     Daycode[] dayOfWeek?;
     time[] timeOfDay?;
     code[] when?;

--- a/r4/datatype_element_slicing.bal
+++ b/r4/datatype_element_slicing.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -75,7 +76,10 @@ public type ElementSlicing record {|
     ElementDiscriminator[] discriminator?;
     string description?;
     boolean ordered?;
-    ElementSlicingRules rules;
+    @constraint:String {
+        pattern: re`closed|open|openAtEnd`
+    }
+    string | ElementSlicingRules rules;
 
 |};
 

--- a/r4/datatype_element_sort.bal
+++ b/r4/datatype_element_sort.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -54,7 +55,10 @@ public type ElementSort record {|
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
     string path;
-    DirectionCode direction;
+    @constraint:String {
+        pattern: re `'ascending | 'descending`
+    }
+    string | DirectionCode direction;
 |};
 
 public enum DirectionCode {

--- a/r4/datatype_element_type.bal
+++ b/r4/datatype_element_type.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -86,7 +87,10 @@ public type ElementType record {|
     uri code;
     canonical[] profile?;
     canonical[] targetProfile?;
-    TypeAggregation[] aggregation?;
+    string | TypeAggregation[] aggregation?;
+    @constraint:String {
+        pattern: re`either|independent|specific`
+    }
     TypeVersioning versioning?;
 |};
 

--- a/r4/datatype_human_name.bal
+++ b/r4/datatype_human_name.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -98,7 +99,10 @@ public type HumanName record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    HumanNameUse use?;
+    @constraint:String {
+        pattern: re`usual|official|temp|nickname|anonymous|old|maiden`
+    }
+    string | HumanNameUse use?;
     string text?;
     string family?;
     string[] given?;

--- a/r4/datatype_identifier.bal
+++ b/r4/datatype_identifier.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -90,7 +91,10 @@ public type Identifier record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    IdentifierUse use?;
+    @constraint:String {
+        pattern: re`usual|official|temp|secondary|old`
+    }
+    string | IdentifierUse use?;
     CodeableConcept 'type?;
     uri system?;
     string value?;

--- a/r4/datatype_narrative.bal
+++ b/r4/datatype_narrative.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -57,7 +58,10 @@ public type Narrative record {|
     Extension[] extension?;
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
-    StatusCode status;
+    @constraint:String {
+        pattern: re`generated|extensions|additional|empty`
+    }
+    string | StatusCode status;
     xhtml div;
 |};
 

--- a/r4/datatype_parameter_definition.bal
+++ b/r4/datatype_parameter_definition.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -101,7 +102,10 @@ public type ParameterDefinition record {|
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
     code name?;
-    ParameterDefinitionUse use;
+    @constraint:String {
+        pattern: re`in|out`
+    }
+    string | ParameterDefinitionUse use;
     integer min?;
     string max?;
     string documentation?;

--- a/r4/datatype_quantity.bal
+++ b/r4/datatype_quantity.bal
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+import ballerina/constraint;
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -84,7 +85,10 @@ public type Quantity record {|
     //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)
 
     decimal value?;
-    QuantityComparatorCode comparator?;
+    @constraint:String {
+        pattern: re`<|<=|>=|>`
+    }
+    string | QuantityComparatorCode comparator?;
     string unit?;
     uri system?;
     code code?;
@@ -172,7 +176,11 @@ public type MoneyQuantity record {|
     decimal moneyValue?;
     string unit?;
     uri system?;
-    code code?;
+    
+    @constraint:String {
+        pattern: re`<|<=|>=|>`
+    }
+    string | QuantityComparatorCode code?;
 |};
 
 public enum QuantityComparatorCode {


### PR DESCRIPTION
## Purpose

**NOTE**: This issue was first detected by FHIR R5 IG parsing, the issue replicated in R4 as well due to tool changes thus breaking an existing R4 profile (USCore700). So, the fix was applied for R4 as well.

This PR fixes an issue where a child element cannot override the base datatype if it uses the same parameter name as the parent. Using the parent’s datatype may remove important characteristics of the child, and removing inheritance would break the relationship between the two elements.

For example, in the FHIR R5 international500 specification, consider the following:
```
public type ObservationbmiValue record {|
    *r5:Quantity;

    ObservationbmiValueComparator comparator?;
    r5:Extension[] extension?;
    string unit;
    r5:code code = "kg/m2";
    r5:uri system = "http://unitsofmeasure.org";
    string id?;
    decimal value;
|};
```

The parent type r5:Quantity contains the following field:
```
public type Quantity record {|
    *Element;
    //Inherited child element from "Element" (Redefining to maintain order when serialize) (START)
    string id?;
    Extension[] extension?;
    //Inherited child element from "Element" (Redefining to maintain order when serialize) (END)

    decimal value?;
    QuantityComparatorCode comparator?;
    string unit?;
    uri system?;
    code code?;
|};
```

Here, the _comparator_ field causes a conflict because it's defined in both the parent and the child but with different datatypes.
Child enum (ObservationbmiValueComparator): 
```
public enum ObservationbmiValueComparator {
   CODE_COMPARATOR_LESS_THAN_OR_EQUAL = "<=",
   CODE_COMPARATOR_AD = "ad",
   CODE_COMPARATOR_LESS_THAN = "<",
   CODE_COMPARATOR_GREATER_THAN = ">",
   CODE_COMPARATOR_GREATER_THAN_OR_EQUAL = ">="
}
```

Parent enum (QuantityComparatorCode): 
```
public enum QuantityComparatorCode {
    LESS_THAN = "<",
    LESS_THAN_EQUAL = "<=",
    GREATER_THAN_EQUAL = ">=",
    GREATER_THAN = ">"
};
```

If the parent's version is used, the child’s specific values like "ad" are lost.

To solve this, the field is redefined in the parent with a union type and a constraint that ensures valid FHIR-compliant values are used at runtime:

```
 @constraint:String {
        pattern: re `^(<|<=|>|>=)$`
    }
    string|QuantityComparatorCode comparator?;
```

## Goals

1. Allow child types to override common field names without losing their unique data.
2. Ensure backward compatibility and validation through constraints.

## Approach
This issue was found while parsing the international500 specification using the Ballerina health tool and comparing the results with the manually created international500 module. The manual version used the parent field directly to avoid the type conflict, but this fix is more robust as it keeps the child’s unique properties intact through a union and constraints.

## Release note
Supports preserving child field definitions (e.g., enums) when overridden from a parent with the same attribute name but different datatype.

## Automation tests
Manually tested using the health tool to confirm that invalid values cannot bypass constraints. The validation works as expected with the new union type and constraint.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes
 
## Samples
N/A

## Related PRs
[[R5] Add union operator for ENUM types](https://github.com/ballerina-platform/module-ballerinax-health.fhir.r5/pull/19)
[Add FHIR R5 support](https://github.com/wso2-enterprise/open-healthcare/issues/1734)

## Migrations (if applicable)
Applied Java 21 and Ballerina 2201.12.3 migration

## Test environment
JDK: 21
Ballerina: 2201.12.3
OS: Windows 11 Pro
 
## Learning
[FHIR R5](https://hl7.org/fhir/R5/)