### PR TITLE
[FHIR Path] Remove unnecessary public apis

### DIFF
--- a/utils/fhirpath/expr.bal
+++ b/utils/fhirpath/expr.bal
@@ -26,7 +26,7 @@
 
 # Base expression type representing any FHIRPath expression node in the AST.
 # This is a union of all possible expression types.
-public type Expr BinaryExpr|LiteralExpr|IdentifierExpr|FunctionExpr|MemberAccessExpr|IndexerExpr;
+type Expr BinaryExpr|LiteralExpr|IdentifierExpr|FunctionExpr|MemberAccessExpr|IndexerExpr;
 
 // ========================================
 // EXPRESSION NODE TYPES
@@ -39,7 +39,7 @@ public type Expr BinaryExpr|LiteralExpr|IdentifierExpr|FunctionExpr|MemberAccess
 # + left - The left operand expression
 # + operator - The operator token (contains the operator type and position)
 # + right - The right operand expression
-public type BinaryExpr record {|
+type BinaryExpr record {|
     "Binary" kind;
     Expr left;
     FhirPathToken operator;
@@ -50,7 +50,7 @@ public type BinaryExpr record {|
 #
 # + kind - The expression kind discriminator (always "Literal")
 # + value - The literal value (number, string, boolean, or nil)
-public type LiteralExpr record {|
+type LiteralExpr record {|
     "Literal" kind;
     anydata? value;
 |};
@@ -60,7 +60,7 @@ public type LiteralExpr record {|
 #
 # + kind - The expression kind discriminator (always "Identifier")
 # + name - The identifier name (can be simple or delimited)
-public type IdentifierExpr record {|
+type IdentifierExpr record {|
     "Identifier" kind;
     string name;
 |};
@@ -71,7 +71,7 @@ public type IdentifierExpr record {|
 # + name - The function name
 # + target - The expression the function is called on (e.g., Patient in Patient.where()), or nil for standalone calls
 # + params - Array of argument expressions passed to the function
-public type FunctionExpr record {|
+type FunctionExpr record {|
     "Function" kind;
     string name;
     Expr? target; // The expression the function is called on (e.g., Patient in Patient.where())
@@ -84,7 +84,7 @@ public type FunctionExpr record {|
 # + kind - The expression kind discriminator (always "MemberAccess")
 # + target - The expression being accessed (left side of the dot)
 # + member - The member/property name being accessed (right side of the dot)
-public type MemberAccessExpr record {|
+type MemberAccessExpr record {|
     "MemberAccess" kind;
     Expr target;
     string member;
@@ -96,7 +96,7 @@ public type MemberAccessExpr record {|
 # + kind - The expression kind discriminator (always "Indexer")
 # + target - The expression being indexed (the collection)
 # + index - The index expression (typically a literal number)
-public type IndexerExpr record {|
+type IndexerExpr record {|
     "Indexer" kind;
     Expr target;
     Expr index;

--- a/utils/fhirpath/fhir_path_processor.bal
+++ b/utils/fhirpath/fhir_path_processor.bal
@@ -25,7 +25,7 @@ configurable boolean inputFHIRResourceValidation = false;
 configurable boolean outputFHIRResourceValidation = false;
 
 # FhirpathResourceValidationError is the error object that is returned when an error occurs during FHIR resource validation.
-public type FHIRPathResourceValidationError distinct error;
+type FHIRPathResourceValidationError distinct error;
 
 # FHIRPathError is the error object that is returned when an error occurs during the evaluation of a FHIRPath expression.
 public type FHIRPathError FHIRPathScannerError|FHIRPathParserError|FHIRPathInterpreterError|FHIRPathResourceValidationError;

--- a/utils/fhirpath/fhir_path_processor.bal
+++ b/utils/fhirpath/fhir_path_processor.bal
@@ -25,7 +25,7 @@ configurable boolean inputFHIRResourceValidation = false;
 configurable boolean outputFHIRResourceValidation = false;
 
 # FhirpathResourceValidationError is the error object that is returned when an error occurs during FHIR resource validation.
-type FHIRPathResourceValidationError distinct error;
+public type FHIRPathResourceValidationError distinct error;
 
 # FHIRPathError is the error object that is returned when an error occurs during the evaluation of a FHIRPath expression.
 public type FHIRPathError FHIRPathScannerError|FHIRPathParserError|FHIRPathInterpreterError|FHIRPathResourceValidationError;

--- a/utils/fhirpath/fhir_path_processor.bal
+++ b/utils/fhirpath/fhir_path_processor.bal
@@ -25,9 +25,9 @@ configurable boolean inputFHIRResourceValidation = false;
 configurable boolean outputFHIRResourceValidation = false;
 
 # FhirpathResourceValidationError is the error object that is returned when an error occurs during FHIR resource validation.
-public type FHIRPathResourceValidationError distinct error;
+type FHIRPathResourceValidationError distinct error;
 
-# Union type for all FHIRPath-related errors
+# FHIRPathError is the error object that is returned when an error occurs during the evaluation of a FHIRPath expression.
 public type FHIRPathError FHIRPathScannerError|FHIRPathParserError|FHIRPathInterpreterError|FHIRPathResourceValidationError;
 
 # Get values of a FHIR resource using a FHIRPath expression

--- a/utils/fhirpath/interpreter.bal
+++ b/utils/fhirpath/interpreter.bal
@@ -28,9 +28,9 @@ type InterpreterError record {|
     FhirPathToken token;
 |};
 
-# Public error type for FHIRPath interpreter runtime errors.
+# Error type for FHIRPath interpreter runtime errors.
 # This error is raised when the interpreter encounters runtime issues.
-public type FHIRPathInterpreterError distinct error<InterpreterError>;
+type FHIRPathInterpreterError distinct error<InterpreterError>;
 
 # Interprets a FHIRPath expression against a JSON context object.
 # This is the main entry point for expression evaluation.

--- a/utils/fhirpath/parser.bal
+++ b/utils/fhirpath/parser.bal
@@ -40,9 +40,9 @@ type ParseError record {|
     FhirPathToken token;
 |};
 
-# Public error type for FHIRPath parser errors.
+# Error type for FHIRPath parser errors.
 # This error is raised when the parser encounters invalid syntax.
-public type FHIRPathParserError distinct error<ParseError>;
+type FHIRPathParserError distinct error<ParseError>;
 
 # Type alias for parse result: an optional expression and updated parser state.
 type ParseResult [Expr?, ParserState];
@@ -78,7 +78,7 @@ isolated function createParserState(FhirPathToken[] tokens) returns ParserState 
 #
 # + tokens - The list of tokens produced by the scanner
 # + return - An expression AST on success, or a FhirpathParserError if parsing fails
-public isolated function parse(FhirPathToken[] tokens) returns FHIRPathParserError|Expr? {
+isolated function parse(FhirPathToken[] tokens) returns FHIRPathParserError|Expr? {
     ParserState state = createParserState(tokens);
     ParseResult result = check Expression(state);
     Expr? expr = result[0];

--- a/utils/fhirpath/scanner.bal
+++ b/utils/fhirpath/scanner.bal
@@ -25,9 +25,9 @@ type ScannerError record {|
     int position;
 |};
 
-# Public error type for FHIRPath scanner errors.
+# Error type for FHIRPath scanner errors.
 # This error is raised when the scanner encounters invalid syntax.
-public type FHIRPathScannerError distinct error<ScannerError>;
+type FHIRPathScannerError distinct error<ScannerError>;
 
 // ========================================
 // STATE MANAGEMENT

--- a/utils/fhirpath/tests/test_empty_and_exists.bal
+++ b/utils/fhirpath/tests/test_empty_and_exists.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 @test:Config {}
-public function testEmptyFunction() returns error? {
+function testEmptyFunction() returns error? {
     // empty() on non-empty collections should return false
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.empty()"), [false], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.address.empty()"), [false], msg = "Failed!");
@@ -41,7 +41,7 @@ public function testEmptyFunction() returns error? {
 }
 
 @test:Config {}
-public function testEmptyFunctionWithoutResourceType() returns error? {
+function testEmptyFunctionWithoutResourceType() returns error? {
     // empty() without resource type prefix
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "name.empty()"), [false], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "address.empty()"), [false], msg = "Failed!");
@@ -51,7 +51,7 @@ public function testEmptyFunctionWithoutResourceType() returns error? {
 }
 
 @test:Config {}
-public function testExistsFunction() returns error? {
+function testExistsFunction() returns error? {
     // exists() on non-empty collections should return true
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.exists()"), [true], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.address.exists()"), [true], msg = "Failed!");
@@ -74,7 +74,7 @@ public function testExistsFunction() returns error? {
 }
 
 @test:Config {}
-public function testExistsFunctionWithCriteria() returns error? {
+function testExistsFunctionWithCriteria() returns error? {
     // exists() with criteria that matches should return true
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.exists(use = 'official')"), [true], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.exists(use = 'usual')"), [true], msg = "Failed!");
@@ -90,7 +90,7 @@ public function testExistsFunctionWithCriteria() returns error? {
 }
 
 @test:Config {}
-public function testExistsFunctionWithoutResourceType() returns error? {
+function testExistsFunctionWithoutResourceType() returns error? {
     // exists() without resource type prefix
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "name.exists()"), [true], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "address.exists()"), [true], msg = "Failed!");
@@ -101,7 +101,7 @@ public function testExistsFunctionWithoutResourceType() returns error? {
 }
 
 @test:Config {}
-public function testEmptyAndExistsAreOpposites() returns error? {
+function testEmptyAndExistsAreOpposites() returns error? {
     // Verify that empty() and exists() return opposite results for the same paths
     json[]|error emptyResult = getValuesFromFhirPath(samplePatient1, "Patient.name.empty()");
     json[]|error existsResult = getValuesFromFhirPath(samplePatient1, "Patient.name.exists()");

--- a/utils/fhirpath/tests/test_first.bal
+++ b/utils/fhirpath/tests/test_first.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 @test:Config {}
-public function testFirstFunction() returns error? {
+function testFirstFunction() returns error? {
     // first() on a multi-element collection should return the first element
     json[]|error result = getValuesFromFhirPath(samplePatient1, "Patient.name.first()");
     if result is json[] {
@@ -57,7 +57,7 @@ public function testFirstFunction() returns error? {
 }
 
 @test:Config {}
-public function testFirstFunctionWithoutResourceType() returns error? {
+function testFirstFunctionWithoutResourceType() returns error? {
     // first() without resource type prefix
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "name.given.first()"), ["Peter"], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "address.city.first()"), ["PleasantVille"], msg = "Failed!");
@@ -66,7 +66,7 @@ public function testFirstFunctionWithoutResourceType() returns error? {
 }
 
 @test:Config {}
-public function testFirstFunctionChainedWithWhere() returns error? {
+function testFirstFunctionChainedWithWhere() returns error? {
     // first() chained after where() with matches
     json[]|error result = getValuesFromFhirPath(samplePatient1, "Patient.name.where(use = 'official').first()");
     if result is json[] {
@@ -84,7 +84,7 @@ public function testFirstFunctionChainedWithWhere() returns error? {
 }
 
 @test:Config {}
-public function testFirstFunctionChainedWithExists() returns error? {
+function testFirstFunctionChainedWithExists() returns error? {
     // first() chained with exists() - should return true when first element exists
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.first().exists()"), [true], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.address.first().exists()"), [true], msg = "Failed!");

--- a/utils/fhirpath/tests/test_get_fhirpath_values.bal
+++ b/utils/fhirpath/tests/test_get_fhirpath_values.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 @test:Config {}
-public function testEvaluateFhirPath() returns error? {
+function testEvaluateFhirPath() returns error? {
     // Unit Test for HappyPaths.
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.id"), ["1"], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.address[0].line[0]"), ["534 Erewhon St"], msg = "Failed!");
@@ -58,7 +58,7 @@ public function testEvaluateFhirPath() returns error? {
 }
 
 @test:Config {}
-public function testEvaluateFhirPathWithoutResourceType() returns error? {
+function testEvaluateFhirPathWithoutResourceType() returns error? {
     // Unit Test for HappyPaths without resource type prefix.
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "id"), ["1"], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "address[0].line[0]"), ["534 Erewhon St"], msg = "Failed!");

--- a/utils/fhirpath/tests/test_get_fhirpath_where.bal
+++ b/utils/fhirpath/tests/test_get_fhirpath_where.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 @test:Config {}
-public function testWhereFunction() returns error? {
+function testWhereFunction() returns error? {
     // Test where() - filter names by use='official'
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.where(use = 'official').family"), ["Chalmers"], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.name.where(use = 'official').use"), ["official"], msg = "Failed!");
@@ -45,7 +45,7 @@ public function testWhereFunction() returns error? {
 }
 
 @test:Config {}
-public function testWhereFunctionWithBooleanOperators() returns error? {
+function testWhereFunctionWithBooleanOperators() returns error? {
     // Test where() with 'and' operator - both conditions match
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.address.where(use = 'home' and city = 'PleasantVille').state"), ["Vic"], msg = "Failed!");
     test:assertEquals(getValuesFromFhirPath(samplePatient1, "Patient.address.where(city = 'Melbourne' and use = 'work').postalCode"), ["3000"], msg = "Failed!");

--- a/utils/fhirpath/token.bal
+++ b/utils/fhirpath/token.bal
@@ -29,7 +29,7 @@
 # + lexeme - The actual text from the source code that forms this token
 # + literal - The interpreted value for literals (e.g., numeric value, string content), null for non-literals
 # + position - The position in the source code where this token starts (zero-based index)
-public type FhirPathToken record {|
+type FhirPathToken record {|
     TokenType tokenType;
     string lexeme;
     anydata? literal;

--- a/utils/fhirpath/token_type.bal
+++ b/utils/fhirpath/token_type.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 // TokenType enum
-public enum TokenType {
+enum TokenType {
     // Single-character tokens
     LEFT_PAREN, // (
     RIGHT_PAREN, // )


### PR DESCRIPTION
## Purpose
To remove unnecessary public types.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR reduces the public API surface of the FHIRPath utility module to improve encapsulation and clarify the module's stable contract. It converts multiple previously exported types and test functions to package-private visibility while preserving internal behavior and interfaces used within the module.

## Changes Made

- Core AST and token types made non-public:
  - `Expr` and concrete AST node types in utils/fhirpath/expr.bal: `BinaryExpr`, `LiteralExpr`, `IdentifierExpr`, `FunctionExpr`, `MemberAccessExpr`, `IndexerExpr`
  - `FhirPathToken` in utils/fhirpath/token.bal
  - `TokenType` enum in utils/fhirpath/token_type.bal

- Error types visibility adjustments (made non-public):
  - `FHIRPathInterpreterError` (utils/fhirpath/interpreter.bal)
  - `FHIRPathParserError` (utils/fhirpath/parser.bal)
  - `FHIRPathScannerError` (utils/fhirpath/scanner.bal)
  - `FHIRPathResourceValidationError` (utils/fhirpath/fhir_path_processor.bal)

- Function visibility:
  - `parse()` in utils/fhirpath/parser.bal → made non-public (`isolated` retained)

- Tests:
  - Removed public visibility from multiple test functions across utils/fhirpath/tests (covering empty, exists, first, where, and evaluation scenarios), making them package-private; test logic unchanged.

These edits are limited to visibility modifiers and minor documentation clarifications; no structural changes to types, function signatures (aside from visibility), or runtime behavior were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->