### PR TITLE
Fix empty value check for search parameters

### DIFF
--- a/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
+++ b/fhirr4/ballerina/src/main/resources/fhirservice/fhir_preprocessor.bal
@@ -732,7 +732,7 @@ public isolated class FHIRPreprocessor {
             // Decode search parameter key and seperate name and modifier
             // Refer: http://hl7.org/fhir/search.html#modifiers
             string[]? paramValues = requestQueryParams[originalParamName];
-            if paramValues is () || paramValues.length() == 0 {
+            if paramValues is () || paramValues.length() == 0 || paramValues[0] == "" {
                 return r4:createFHIRError(string `Search parameter ${originalParamName} has no value`, r4:ERROR, r4:PROCESSING,
                         httpStatusCode = http:STATUS_BAD_REQUEST);
             }


### PR DESCRIPTION
## Purpose
Fix empty value check for search params for the case `searchParam=`  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request improves input validation for search parameters in the FHIR preprocessor. The change enhances the validation logic to properly handle search parameters that are explicitly provided with empty values (for example, `searchParam=` with no value after the equals sign). 

The modification adds an additional check to treat empty parameter values the same as missing or absent parameters, returning a BAD_REQUEST error when such cases are encountered. This ensures more consistent validation behavior and prevents empty search parameter values from being processed further in the request pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->